### PR TITLE
Defer Requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,13 @@ readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
 
 [dependencies]
+async-trait = "0"
 config = {version="0", default-features = false, features = ["ini"]}
+log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["net",  "sync", "macros", "time"] }
-log = { version = "0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
 
 [dependencies]
-async-trait = "0"
 config = {version="0", default-features = false, features = ["ini"]}
 log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }

--- a/src/ap/client.rs
+++ b/src/ap/client.rs
@@ -42,7 +42,7 @@ impl RequestClient {
     pub async fn get_status(&self) -> Result<Status> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Status(response)).await?;
-        Ok(request.await??)
+        request.await?
     }
 
     pub async fn shutdown(&self) -> Result {

--- a/src/ap/client.rs
+++ b/src/ap/client.rs
@@ -2,13 +2,22 @@ use super::*;
 
 #[derive(Debug)]
 pub(crate) enum Request {
-    Status(oneshot::Sender<Status>),
+    Status(oneshot::Sender<Result<Status>>),
     Shutdown,
 }
 
+#[async_trait]
 impl ShutdownSignal for Request {
     fn is_shutdown(&self) -> bool {
         matches!(self, Request::Shutdown)
+    }
+    async fn inform_of_shutdown(self) {
+        match self {
+            Request::Status(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::Shutdown => {}
+        }
     }
 }
 
@@ -34,7 +43,7 @@ impl RequestClient {
     pub async fn get_status(&self) -> Result<Status> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Status(response)).await?;
-        Ok(request.await?)
+        Ok(request.await??)
     }
 
     pub async fn shutdown(&self) -> Result {

--- a/src/ap/client.rs
+++ b/src/ap/client.rs
@@ -6,12 +6,11 @@ pub(crate) enum Request {
     Shutdown,
 }
 
-#[async_trait]
 impl ShutdownSignal for Request {
     fn is_shutdown(&self) -> bool {
         matches!(self, Request::Shutdown)
     }
-    async fn inform_of_shutdown(self) {
+    fn inform_of_shutdown(self) {
         match self {
             Request::Status(response) => {
                 let _ = response.send(Err(error::Error::StartupAborted));

--- a/src/ap/event_socket.rs
+++ b/src/ap/event_socket.rs
@@ -18,17 +18,18 @@ impl EventSocket {
     pub(crate) async fn new<P>(
         socket: P,
         request_receiver: &mut mpsc::Receiver<Request>,
-    ) -> Result<(EventReceiver, Self)>
+    ) -> Result<(EventReceiver, Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
     {
-        let socket_handle =
+        let (socket_handle, deferred_requests) =
             SocketHandle::open(socket, "mapper_hostapd_async.sock", request_receiver).await?;
 
         // setup the channel for client requests
         let (sender, receiver) = mpsc::channel(32);
         Ok((
             receiver,
+            deferred_requests,
             Self {
                 socket_handle,
                 sender,

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -109,7 +109,7 @@ impl WifiAp {
                 let data_str = std::str::from_utf8(&socket_handle.buffer[..n])?.trim_end();
                 let status = Status::from_response(data_str)?;
 
-                if response_channel.send(status).is_err() {
+                if response_channel.send(Ok(status)).is_err() {
                     error!("Status request response channel closed before response sent");
                 }
             }

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -25,7 +25,6 @@ pub struct WifiAp {
     broadcast_sender: broadcast::Sender<Broadcast>,
     /// Channel for sending requests to itself
     self_sender: mpsc::Sender<Request>,
-
 }
 
 impl WifiAp {

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -23,21 +23,28 @@ pub struct WifiAp {
     #[allow(unused)]
     /// Channel for broadcasting alerts
     broadcast_sender: broadcast::Sender<Broadcast>,
+    /// Channel for sending requests to itself
+    self_sender: mpsc::Sender<Request>,
+
 }
 
 impl WifiAp {
     pub async fn run(mut self) -> Result {
         info!("Starting Wifi AP process");
-        let (event_receiver, event_socket) =
+        let (event_receiver, mut deferred_requests, event_socket) =
             EventSocket::new(&self.socket_path, &mut self.request_receiver).await?;
         // We start up a separate socket for receiving the "unexpected" events that
         // gets forwarded to us via the event_receiver
-        let socket_handle = SocketHandle::open(
+        let (socket_handle, next_deferred_requests) = SocketHandle::open(
             &self.socket_path,
             "mapper_hostapd_sync.sock",
             &mut self.request_receiver,
         )
         .await?;
+        deferred_requests.extend(next_deferred_requests);
+        for request in deferred_requests {
+            let _ = self.self_sender.send(request).await;
+        }
         self.broadcast_sender.send(Broadcast::Ready)?;
         tokio::select!(
             resp = event_socket.run() => resp,

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -18,8 +18,8 @@ pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
 impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     pub fn new() -> Result<Self> {
         // setup the channel for client requests
-        let (sender, request_receiver) = mpsc::channel(C);
-        let request_client = RequestClient::new(sender);
+        let (self_sender, request_receiver) = mpsc::channel(C);
+        let request_client = RequestClient::new(self_sender.clone());
         // setup the channel for broadcasts
         let (broadcast_sender, broadcast_receiver) = broadcast::channel(B);
 
@@ -28,6 +28,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 socket_path: PATH_DEFAULT_SERVER.into(),
                 request_receiver,
                 broadcast_sender,
+                self_sender,
             },
             request_client,
             broadcast_receiver,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,7 @@ pub type Result<T = ()> = std::result::Result<T, error::Error>;
 
 use log::{debug, error, info, warn};
 
-use async_trait::async_trait;
-#[async_trait]
 pub(crate) trait ShutdownSignal {
     fn is_shutdown(&self) -> bool;
-    async fn inform_of_shutdown(self);
+    fn inform_of_shutdown(self);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub type Result<T = ()> = std::result::Result<T, error::Error>;
 
 use log::{debug, error, info, warn};
 
+use async_trait::async_trait;
+#[async_trait]
 pub(crate) trait ShutdownSignal {
     fn is_shutdown(&self) -> bool;
+    async fn inform_of_shutdown(self);
 }

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -74,11 +74,14 @@ impl<const N: usize> SocketHandle<N> {
             return Err(error::Error::StartupAborted);
         }
 
-        Ok((Self {
-            tmp_dir,
-            socket: socket?,
-            buffer: [0; N],
-        }, deferred_requests))
+        Ok((
+            Self {
+                tmp_dir,
+                socket: socket?,
+                buffer: [0; N],
+            },
+            deferred_requests,
+        ))
     }
 
     pub async fn command(&mut self, cmd: &[u8]) -> Result {

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -18,7 +18,7 @@ impl<const N: usize> SocketHandle<N> {
         path: P,
         label: &str,
         request_channel: &mut mpsc::Receiver<S>,
-    ) -> Result<Self>
+    ) -> Result<(Self, Vec<S>)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
         S: ShutdownSignal,
@@ -28,6 +28,8 @@ impl<const N: usize> SocketHandle<N> {
         let socket = UnixDatagram::bind(connect_from)?;
         let socket_debug = &format!("{path:?}");
         // loop around waiting for the socket for up to 5 minutes
+        let mut deferred_requests = Vec::new();
+        let deferred_requests_handle = &mut deferred_requests;
         let socket = tokio::select!(
             resp = async move  {
                 let mut loop_count = 0;
@@ -57,17 +59,26 @@ impl<const N: usize> SocketHandle<N> {
                     if let Some(request) = request_channel.recv().await {
                         if request.is_shutdown() {
                             break;
+                        } else {
+                            deferred_requests_handle.push(request);
                         }
                     }
                 }
             } => Err(error::Error::StartupAborted),
-        )?;
+        );
 
-        Ok(Self {
+        if let Err(error::Error::StartupAborted) = socket {
+            for request in deferred_requests {
+                request.inform_of_shutdown();
+            }
+            return Err(error::Error::StartupAborted);
+        }
+
+        Ok((Self {
             tmp_dir,
-            socket,
+            socket: socket?,
             buffer: [0; N],
-        })
+        }, deferred_requests))
     }
 
     pub async fn command(&mut self, cmd: &[u8]) -> Result {

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -105,13 +105,13 @@ impl RequestClient {
     pub async fn get_scan(&self) -> Result<Arc<Vec<ScanResult>>> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Scan(response)).await?;
-        Ok(request.await??)
+        request.await?
     }
 
     pub async fn get_networks(&self) -> Result<Vec<NetworkResult>> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Networks(response)).await?;
-        Ok(request.await??)
+        request.await?
     }
 
     pub async fn get_status(&self) -> Result<Status> {
@@ -123,7 +123,7 @@ impl RequestClient {
     pub async fn add_network(&self) -> Result<usize> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::AddNetwork(response)).await?;
-        Ok(request.await??)
+        request.await?
     }
 
     pub async fn set_network_psk(&self, network_id: usize, psk: String) -> Result {

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -32,19 +32,49 @@ impl fmt::Display for SelectResult {
 #[derive(Debug)]
 pub(crate) enum Request {
     Status(oneshot::Sender<Result<Status>>),
-    Networks(oneshot::Sender<Vec<NetworkResult>>),
-    Scan(oneshot::Sender<ScanResults>),
-    AddNetwork(oneshot::Sender<usize>),
-    SetNetwork(usize, SetNetwork),
-    SaveConfig,
-    RemoveNetwork(usize),
-    SelectNetwork(usize, oneshot::Sender<SelectResult>),
+    Networks(oneshot::Sender<Result<Vec<NetworkResult>>>),
+    Scan(oneshot::Sender<Result<ScanResults>>),
+    AddNetwork(oneshot::Sender<Result<usize>>),
+    SetNetwork(usize, SetNetwork, oneshot::Sender<Result>),
+    SaveConfig(oneshot::Sender<Result>),
+    RemoveNetwork(usize, oneshot::Sender<Result>),
+    SelectNetwork(usize, oneshot::Sender<Result<SelectResult>>),
     Shutdown,
 }
 
+#[async_trait]
 impl ShutdownSignal for Request {
     fn is_shutdown(&self) -> bool {
         matches!(self, Request::Shutdown)
+    }
+    async fn inform_of_shutdown(self) {
+        match self {
+            Request::Status(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::Networks(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::Scan(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::AddNetwork(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::SetNetwork(_, _, response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::SaveConfig(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::RemoveNetwork(_, response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::SelectNetwork(_, response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::Shutdown => {}
+        }
     }
 }
 
@@ -76,13 +106,13 @@ impl RequestClient {
     pub async fn get_scan(&self) -> Result<Arc<Vec<ScanResult>>> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Scan(response)).await?;
-        Ok(request.await?)
+        Ok(request.await??)
     }
 
     pub async fn get_networks(&self) -> Result<Vec<NetworkResult>> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::Networks(response)).await?;
-        Ok(request.await?)
+        Ok(request.await??)
     }
 
     pub async fn get_status(&self) -> Result<Status> {
@@ -94,37 +124,51 @@ impl RequestClient {
     pub async fn add_network(&self) -> Result<usize> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::AddNetwork(response)).await?;
-        Ok(request.await?)
+        Ok(request.await??)
     }
 
     pub async fn set_network_psk(&self, network_id: usize, psk: String) -> Result {
-        self.send_request(Request::SetNetwork(network_id, SetNetwork::Psk(psk)))
-            .await?;
-        Ok(())
+        let (response, request) = oneshot::channel();
+
+        self.send_request(Request::SetNetwork(
+            network_id,
+            SetNetwork::Psk(psk),
+            response,
+        ))
+        .await?;
+        request.await?
     }
 
     pub async fn set_network_ssid(&self, network_id: usize, ssid: String) -> Result {
-        self.send_request(Request::SetNetwork(network_id, SetNetwork::Ssid(ssid)))
-            .await?;
-        Ok(())
+        let (response, request) = oneshot::channel();
+        self.send_request(Request::SetNetwork(
+            network_id,
+            SetNetwork::Ssid(ssid),
+            response,
+        ))
+        .await?;
+        request.await?
     }
 
     pub async fn save_config(&self) -> Result {
-        self.send_request(Request::SaveConfig).await?;
-        Ok(())
+        let (response, request) = oneshot::channel();
+
+        self.send_request(Request::SaveConfig(response)).await?;
+        request.await?
     }
 
     pub async fn remove_network(&self, network_id: usize) -> Result {
-        self.send_request(Request::RemoveNetwork(network_id))
+        let (response, request) = oneshot::channel();
+        self.send_request(Request::RemoveNetwork(network_id, response))
             .await?;
-        Ok(())
+        request.await?
     }
 
     pub async fn select_network(&self, network_id: usize) -> Result<SelectResult> {
         let (response, request) = oneshot::channel();
         self.send_request(Request::SelectNetwork(network_id, response))
             .await?;
-        Ok(request.await?)
+        request.await?
     }
 
     pub async fn shutdown(&self) -> Result {

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -42,12 +42,11 @@ pub(crate) enum Request {
     Shutdown,
 }
 
-#[async_trait]
 impl ShutdownSignal for Request {
     fn is_shutdown(&self) -> bool {
         matches!(self, Request::Shutdown)
     }
-    async fn inform_of_shutdown(self) {
+    fn inform_of_shutdown(self) {
         match self {
             Request::Status(response) => {
                 let _ = response.send(Err(error::Error::StartupAborted));

--- a/src/sta/event_socket.rs
+++ b/src/sta/event_socket.rs
@@ -21,15 +21,17 @@ impl EventSocket {
     pub(crate) async fn new<P>(
         socket: P,
         request_receiver: &mut mpsc::Receiver<Request>,
-    ) -> Result<(EventReceiver, Self)>
+    ) -> Result<(EventReceiver, Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
     {
-        let socket_handle =
+        let (socket_handle, deferred_requests) =
             SocketHandle::open(socket, "mapper_wpa_ctrl_async.sock", request_receiver).await?;
+        // setup the channel for client requests
         let (sender, receiver) = mpsc::channel(32);
         Ok((
             receiver,
+            deferred_requests,
             Self {
                 socket_handle,
                 sender,

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -18,8 +18,8 @@ pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
 impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     pub fn new() -> Result<Self> {
         // setup the channel for client requests
-        let (sender, request_receiver) = mpsc::channel(C);
-        let request_client = RequestClient::new(sender);
+        let (self_sender, request_receiver) = mpsc::channel(C);
+        let request_client = RequestClient::new(self_sender.clone());
         // setup the channel for broadcasts
         let (broadcast_sender, broadcast_receiver) = broadcast::channel(B);
 
@@ -28,6 +28,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 socket_path: PATH_DEFAULT_SERVER.into(),
                 request_receiver,
                 broadcast_sender,
+                self_sender
             },
             request_client,
             broadcast_receiver,

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -28,7 +28,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 socket_path: PATH_DEFAULT_SERVER.into(),
                 request_receiver,
                 broadcast_sender,
-                self_sender
+                self_sender,
             },
             request_client,
             broadcast_receiver,


### PR DESCRIPTION
1553575a8c81a56f6199a4975bf4018ccc3c8294 provided early shutdown, but doing so provides an ominous error to clients.

This commit defers requests until the process is fully initialized and sends the early startup abort error back to the client if the start up is aborted.