### PR TITLE
Timeout Selects. Check if already connected.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 tempfile = "3"
-tokio = { version = "1", default-features = false, features = ["net",  "sync", "macros", "time"] }
+tokio = { version = "1", default-features = false, features = ["net",  "rt", "sync", "macros", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub enum Error {
     WifiApBroadcast(#[from] broadcast::error::SendError<ap::Broadcast>),
     #[error("wifi::sta broadcast: {0}")]
     WifiStaBroadcast(#[from] broadcast::error::SendError<sta::Broadcast>),
-    #[error("wifi sta select result")]
-    WifiSelect,
     #[error("timeout opening socket {0}")]
     TimeoutOpeningSocket(String),
     #[error("permission denied opening socket {0}")]

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -15,6 +15,7 @@ pub enum SelectResult {
     PendingSelect,
     InvalidNetworkId,
     Timeout,
+    AlreadyConnected,
 }
 
 use std::fmt;
@@ -28,6 +29,7 @@ impl fmt::Display for SelectResult {
             SelectResult::PendingSelect => "select_already_pending",
             SelectResult::InvalidNetworkId => "invalid_network_id",
             SelectResult::Timeout => "select_timeout",
+            SelectResult::AlreadyConnected => "already_connected",
         };
         write!(f, "{s}")
     }

--- a/src/sta/event_socket.rs
+++ b/src/sta/event_socket.rs
@@ -49,7 +49,6 @@ impl EventSocket {
 
     pub(crate) async fn run(mut self) -> Result {
         info!("wpa_ctrl attempting attach");
-
         self.socket_handle.socket.send(b"ATTACH").await?;
         loop {
             match self

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -135,9 +135,7 @@ impl WifiStation {
             Event::Connected => {
                 broadcast_sender.send(Broadcast::Connected)?;
                 if let Some(sender) = select_request.take() {
-                    sender
-                        .send(Ok(SelectResult::Success))
-                        .map_err(|_| error::Error::WifiSelect)?;
+                    let _ = sender.send(Ok(SelectResult::Success));
                 }
             }
             Event::Disconnected => {
@@ -146,17 +144,13 @@ impl WifiStation {
             Event::NetworkNotFound => {
                 broadcast_sender.send(Broadcast::NetworkNotFound)?;
                 if let Some(sender) = select_request.take() {
-                    sender
-                        .send(Ok(SelectResult::NotFound))
-                        .map_err(|_| error::Error::WifiSelect)?;
+                    let _ = sender.send(Ok(SelectResult::NotFound));
                 }
             }
             Event::WrongPsk => {
                 broadcast_sender.send(Broadcast::WrongPsk)?;
                 if let Some(sender) = select_request.take() {
-                    sender
-                        .send(Ok(SelectResult::WrongPsk))
-                        .map_err(|_| error::Error::WifiSelect)?;
+                    let _ = sender.send(Ok(SelectResult::WrongPsk));
                 }
             }
         }
@@ -174,9 +168,7 @@ impl WifiStation {
         match request {
             Request::SelectTimeout => {
                 if let Some(sender) = select_request.take() {
-                    sender
-                        .send(Ok(SelectResult::NotFound))
-                        .map_err(|_| error::Error::WifiSelect)?;
+                    let _ = sender.send(Ok(SelectResult::NotFound));
                 }
             }
             Request::Scan(response_channel) => {
@@ -253,9 +245,7 @@ impl WifiStation {
                         let bytes = cmd.into_bytes();
                         if let Err(e) = socket_handle.command(&bytes).await {
                             warn!("Error while selecting network {id}: {e}");
-                            response_sender
-                                .send(Ok(SelectResult::InvalidNetworkId))
-                                .map_err(|_| error::Error::WifiSelect)?;
+                            let _ = response_sender.send(Ok(SelectResult::InvalidNetworkId));
                             None
                         } else {
                             debug!("wpa_ctrl selected network {id}");
@@ -264,9 +254,7 @@ impl WifiStation {
                     }
                     Some(_) => {
                         warn!("Select request already pending! Dropping this one.");
-                        response_sender
-                            .send(Ok(SelectResult::PendingSelect))
-                            .map_err(|_| error::Error::WifiSelect)?;
+                        let _ = response_sender.send(Ok(SelectResult::PendingSelect));
                         debug!("wpa_ctrl removed network {id}");
                         None
                     }

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -168,7 +168,7 @@ impl WifiStation {
         match request {
             Request::SelectTimeout => {
                 if let Some(sender) = select_request.take() {
-                    let _ = sender.send(Ok(SelectResult::NotFound));
+                    let _ = sender.send(Ok(SelectResult::Timeout));
                 }
             }
             Request::Scan(response_channel) => {

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -29,6 +29,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 request_receiver,
                 broadcast_sender,
                 self_sender,
+                select_timeout: Duration::from_secs(10),
             },
             request_client,
             broadcast_receiver,
@@ -38,6 +39,11 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     pub fn set_socket_path<S: Into<std::path::PathBuf>>(&mut self, path: S) {
         self.wifi.socket_path = path.into();
     }
+
+    pub fn set_select_timeout(&mut self, timeout: Duration) {
+        self.wifi.select_timeout = timeout;
+    }
+
     pub fn get_broadcast_receiver(&self) -> BroadcastReceiver {
         self.wifi.broadcast_sender.subscribe()
     }


### PR DESCRIPTION
Sometimes a select appears to be successful but there's no response. The caller will `await` forever and the wifi-ctrl::sta process is incapable of handling further requests.

While there might be some unparsed message underlying this issue, this timeout keeps everything from just getting stuck. Further testing with debug logs might reveal the unparsed message.