### PR TITLE
Add support for more `hostapd` control interface commands

### DIFF
--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -119,6 +119,16 @@ impl WifiAp {
                     error!("Status request response channel closed before response sent");
                 }
             }
+            Request::Config(response_channel) => {
+                let _n = socket_handle.socket.send(b"GET_CONFIG").await?;
+                let n = socket_handle.socket.recv(&mut socket_handle.buffer).await?;
+                let data_str = std::str::from_utf8(&socket_handle.buffer[..n])?.trim_end();
+                let config = Config::from_response(data_str)?;
+
+                if response_channel.send(Ok(config)).is_err() {
+                    error!("Config request response channel closed before response sent");
+                }
+            }
             Request::Shutdown => (), //shutdown is handled at the scope above
         }
         Ok(())

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -135,6 +135,11 @@ impl WifiAp {
             Request::Disable(response_channel) => {
                 Self::ok_fail_request(socket_handle, b"DISABLE", response_channel).await?
             }
+            Request::SetValue(key, value, response_channel) => {
+                let request_string = format!("SET {key} {value}");
+                Self::ok_fail_request(socket_handle, request_string.as_bytes(), response_channel)
+                    .await?
+            }
             Request::Shutdown => (), //shutdown is handled at the scope above
         }
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     StartupAborted,
     #[error("error parsing wifi status {e}: \n{s}")]
     ParsingWifiStatus { e: config::ConfigError, s: String },
+    #[error("error parsing wifi config {e}: \n{s}")]
+    ParsingWifiConfig { e: config::ConfigError, s: String },
     #[error("unexpected wifi ap response: {0}")]
     UnexpectedWifiApRepsonse(String),
     #[error("timeout waiting for response")]


### PR DESCRIPTION
This PR introduces a couple of APIs controlling (and querying) `hostapd`. The use case I'm working on is fairly limited so far, so this only includes `get_config`, `enable`/`disable`, and `set`; the latter is implemented in terms of passing a `String` key/value pair.