### PR TITLE
add method to remove all networks

### DIFF
--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -44,6 +44,7 @@ pub(crate) enum Request {
     SetNetwork(usize, SetNetwork, oneshot::Sender<Result>),
     SaveConfig(oneshot::Sender<Result>),
     RemoveNetwork(usize, oneshot::Sender<Result>),
+    RemoveAllNetworks(oneshot::Sender<Result>),
     SelectNetwork(usize, oneshot::Sender<Result<SelectResult>>),
     Shutdown,
     SelectTimeout,
@@ -74,6 +75,9 @@ impl ShutdownSignal for Request {
                 let _ = response.send(Err(error::Error::StartupAborted));
             }
             Request::RemoveNetwork(_, response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::RemoveAllNetworks(response) => {
                 let _ = response.send(Err(error::Error::StartupAborted));
             }
             Request::SelectNetwork(_, response) => {
@@ -177,6 +181,13 @@ impl RequestClient {
     pub async fn remove_network(&self, network_id: usize) -> Result {
         let (response, request) = oneshot::channel();
         self.send_request(Request::RemoveNetwork(network_id, response))
+            .await?;
+        request.await?
+    }
+
+    pub async fn remove_all_networks(&self) -> Result {
+        let (response, request) = oneshot::channel();
+        self.send_request(Request::RemoveAllNetworks(response))
             .await?;
         request.await?
     }

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -92,6 +92,7 @@ impl ShutdownSignal for Request {
 #[derive(Debug)]
 pub(crate) enum SetNetwork {
     Ssid(String),
+    Bssid(String),
     Psk(String),
     KeyMgmt(KeyMgmt),
 }
@@ -155,6 +156,17 @@ impl RequestClient {
         self.send_request(Request::SetNetwork(
             network_id,
             SetNetwork::Ssid(ssid),
+            response,
+        ))
+        .await?;
+        request.await?
+    }
+
+    pub async fn set_network_bssid(&self, network_id: usize, bssid: String) -> Result {
+        let (response, request) = oneshot::channel();
+        self.send_request(Request::SetNetwork(
+            network_id,
+            SetNetwork::Bssid(bssid),
             response,
         ))
         .await?;

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -216,6 +216,7 @@ impl WifiStation {
                     "SET_NETWORK {id} {}",
                     match param {
                         SetNetwork::Ssid(ssid) => format!("ssid \"{ssid}\""),
+                        SetNetwork::Bssid(bssid) => format!("bssid \"{bssid}\""),
                         SetNetwork::Psk(psk) => format!("psk \"{psk}\""),
                         SetNetwork::KeyMgmt(mgmt) => format!("key_mgmt {}", mgmt.to_string()),
                     }

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -243,6 +243,13 @@ impl WifiStation {
                 debug!("wpa_ctrl removed network {id}");
                 let _ = response.send(Ok(()));
             }
+            Request::RemoveAllNetworks(response) => {
+                if let Err(e) = socket_handle.command(b"REMOVE_NETWORK all").await {
+                    warn!("Error while removing network all: {e}");
+                }
+                debug!("wpa_ctrl removed network all");
+                let _ = response.send(Ok(()));
+            }
             Request::SelectNetwork(id, response_sender) => {
                 let response_sender = match select_request {
                     None => {


### PR DESCRIPTION
Removing all networks is the same as removing one network but with the special id `"all"` instead of a network number.