### PR TITLE
Add support for unicode in SSIDs and PSKs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
 
 [dependencies]
-config = {version="0", default-features = false, features = ["ini"]}
 hex = "0.4"
 log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
 
 [dependencies]
 config = {version="0", default-features = false, features = ["ini"]}
+hex = "0.4"
 log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if self.only()?.is_empty() {
+        if self.only()?.is_empty() || self.only()? == "N/A" {
             visitor.visit_none()
         } else {
             visitor.visit_some(self)
@@ -196,7 +196,6 @@ pub(crate) fn unprintf(escaped: &str) -> std::result::Result<String, ConfigError
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,212 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use serde::de::value::MapDeserializer;
+use serde::de::{self, Error, IntoDeserializer, Visitor};
+use serde::{forward_to_deserialize_any, Deserialize};
+
+type Result<T> = std::result::Result<T, ConfigError>;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
+pub enum ConfigError {
+    #[error("Missing '=' delimiter in config line")]
+    MissingDelimterEqual,
+    #[error("escape code is not made up of valid hex code")]
+    InvalidEscape,
+    #[error("escape code is incomplete")]
+    IncompleteEscape,
+    #[error("escaped value is not valid uft8 after unescaping")]
+    NonUtf8Escape,
+    #[error("Value could not be decoded")]
+    SerdeError(String),
+}
+
+impl Error for ConfigError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::SerdeError(msg.to_string())
+    }
+}
+
+#[derive(Default)]
+pub struct Deserializer<'de> {
+    input: Vec<&'de str>,
+}
+
+impl<'de> Deserializer<'de> {
+    fn only(&self) -> Result<&'de str> {
+        if self.input.len() == 1 {
+            Ok(self.input[0])
+        } else {
+            Err(ConfigError::SerdeError("did not expect seq".to_owned()))
+        }
+    }
+}
+
+impl<'de> IntoDeserializer<'de, ConfigError> for Deserializer<'de> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let mut map: HashMap<&str, Deserializer<'_>> = HashMap::new();
+    for line in s.trim().lines() {
+        let (k, v) = line
+            .split_once('=')
+            .ok_or(ConfigError::MissingDelimterEqual)?;
+        let (k, i) = if let Some((k, i)) = k.split_once('[') {
+            if let Some((i, "")) = i.rsplit_once(']') {
+                (k, i.parse().map_err(ConfigError::custom)?)
+            } else {
+                return Err(ConfigError::custom("invalid key"));
+            }
+        } else {
+            (k, 0)
+        };
+        let values = &mut map.entry(k.trim()).or_default().input;
+        if values.len() != i {
+            return Err(ConfigError::custom("Duplicate key"));
+        }
+        values.push(v);
+    }
+    T::deserialize(MapDeserializer::new(map.into_iter()))
+}
+
+macro_rules! forward_to_from_str {
+    ($func:ident $method:ident) => {
+        #[inline]
+        fn $func<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.$method(self.only()?.parse().map_err(ConfigError::custom)?)
+        }
+    };
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+    type Error = ConfigError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.only()? {
+            "true" | "TRUE" | "enabled" | "ENABLED" => visitor.visit_bool(true),
+            "false" | "FALSE" | "disabled" | "DISABLED" => visitor.visit_bool(false),
+            s => Err(ConfigError::SerdeError(format!("Invalid bool {}", s))),
+        }
+    }
+
+    forward_to_from_str!(deserialize_i8  visit_i8);
+    forward_to_from_str!(deserialize_i16 visit_i16);
+    forward_to_from_str!(deserialize_i32 visit_i32);
+    forward_to_from_str!(deserialize_i64 visit_i64);
+
+    forward_to_from_str!(deserialize_u8  visit_u8);
+    forward_to_from_str!(deserialize_u16 visit_u16);
+    forward_to_from_str!(deserialize_u32 visit_u32);
+    forward_to_from_str!(deserialize_u64 visit_u64);
+
+    forward_to_from_str!(deserialize_f32 visit_f32);
+    forward_to_from_str!(deserialize_f64 visit_f64);
+
+    forward_to_from_str!(deserialize_char visit_char);
+
+    // these are not really supported (nor used) as deserialize_any will always deserialize to a String
+    forward_to_deserialize_any! {str unit unit_struct bytes byte_buf map struct newtype_struct enum tuple tuple_struct identifier ignored_any}
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(unprintf(self.only()?)?)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.only()?.is_empty() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(
+            self.input
+                .into_iter()
+                .map(|s| Deserializer { input: vec![s] })
+                .collect::<Vec<_>>()
+                .into_deserializer(),
+        )
+    }
+}
+
+pub(crate) fn unprintf(escaped: &str) -> std::result::Result<String, ConfigError> {
+    let mut bytes = escaped.as_bytes().iter().copied();
+    let mut unescaped = vec![];
+    // undo "printf_encode"
+    loop {
+        unescaped.push(match bytes.next() {
+            Some(b'\\') => match bytes.next().ok_or(ConfigError::IncompleteEscape)? {
+                b'n' => b'\n',
+                b'r' => b'\r',
+                b't' => b'\t',
+                b'e' => b'\x1b',
+                b'x' => {
+                    let hex = [
+                        bytes.next().ok_or(ConfigError::IncompleteEscape)?,
+                        bytes.next().ok_or(ConfigError::IncompleteEscape)?,
+                    ];
+                    u8::from_str_radix(
+                        std::str::from_utf8(&hex).or(Err(ConfigError::InvalidEscape))?,
+                        16,
+                    )
+                    .or(Err(ConfigError::InvalidEscape))?
+                }
+                c => c,
+            },
+            Some(c) => c,
+            None => break,
+        })
+    }
+    String::from_utf8(unescaped).or(Err(ConfigError::NonUtf8Escape))
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_deserializer() {
+        let resp = r#"
+        state=ENABLED
+        shrug=¯\\_(\xe3\x83\x84)_/¯
+        "#;
+        let status: HashMap<String, String> = from_str(resp).unwrap();
+        assert_eq!(status.get("state").unwrap(), "ENABLED");
+        assert_eq!(status.get("shrug").unwrap(), r#"¯\_(ツ)_/¯"#);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 /// WiFi Station (network client) runtime and types
 pub mod sta;
 
+pub(crate) mod config;
 pub(crate) mod socket_handle;
 
 use socket_handle::SocketHandle;

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -50,6 +50,7 @@ pub(crate) enum Request {
     AddNetwork(oneshot::Sender<Result<usize>>),
     SetNetwork(usize, SetNetwork, oneshot::Sender<Result>),
     SaveConfig(oneshot::Sender<Result>),
+    ReloadConfig(oneshot::Sender<Result>),
     RemoveNetwork(RemoveNetwork, oneshot::Sender<Result>),
     SelectNetwork(usize, oneshot::Sender<Result<SelectResult>>),
     Shutdown,
@@ -81,6 +82,9 @@ impl ShutdownSignal for Request {
                 let _ = response.send(Err(error::Error::StartupAborted));
             }
             Request::SaveConfig(response) => {
+                let _ = response.send(Err(error::Error::StartupAborted));
+            }
+            Request::ReloadConfig(response) => {
                 let _ = response.send(Err(error::Error::StartupAborted));
             }
             Request::RemoveNetwork(_, response) => {
@@ -199,6 +203,12 @@ impl RequestClient {
     pub async fn save_config(&self) -> Result {
         let (response, request) = oneshot::channel();
         self.send_request(Request::SaveConfig(response)).await?;
+        request.await?
+    }
+
+    pub async fn reload_config(&self) -> Result {
+        let (response, request) = oneshot::channel();
+        self.send_request(Request::ReloadConfig(response)).await?;
         request.await?
     }
 

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -247,6 +247,13 @@ impl WifiStation {
                 debug!("wpa_ctrl config saved");
                 let _ = response.send(Ok(()));
             }
+            Request::ReloadConfig(response) => {
+                if let Err(e) = socket_handle.command(b"RECONFIGURE").await {
+                    warn!("Error while reloading config: {e}");
+                }
+                debug!("wpa_ctrl config reloaded");
+                let _ = response.send(Ok(()));
+            }
             Request::RemoveNetwork(remove_network, response) => {
                 let str = match remove_network {
                     RemoveNetwork::All => "all".to_string(),

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -122,7 +122,7 @@ impl WifiStation {
                 let _n = socket_handle.socket.send(b"SCAN_RESULTS").await?;
                 let n = socket_handle.socket.recv(&mut socket_handle.buffer).await?;
                 let data_str = std::str::from_utf8(&socket_handle.buffer[..n])?;
-                let mut scan_results = ScanResult::vec_from_str(data_str)?;
+                let mut scan_results = ScanResult::vec_from_str(data_str);
                 scan_results.sort_by(|a, b| a.signal.cmp(&b.signal));
 
                 let results = Arc::new(scan_results);

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -227,9 +227,9 @@ impl WifiStation {
                 let cmd = format!(
                     "SET_NETWORK {id} {}",
                     match param {
-                        SetNetwork::Ssid(ssid) => format!("ssid \"{ssid}\""),
+                        SetNetwork::Ssid(ssid) => format!("ssid {}", conf_escape(&ssid)),
                         SetNetwork::Bssid(bssid) => format!("bssid \"{bssid}\""),
-                        SetNetwork::Psk(psk) => format!("psk \"{psk}\""),
+                        SetNetwork::Psk(psk) => format!("psk {}", conf_escape(&psk)),
                         SetNetwork::KeyMgmt(mgmt) => format!("key_mgmt {}", mgmt),
                     }
                 );
@@ -303,6 +303,16 @@ impl WifiStation {
             Request::Shutdown => (), //shutdown is handled at the scope above
         }
         Ok(())
+    }
+}
+
+/// convert to wpa config format idealy a "quoted string"
+/// in case of new-lines, quotes or emoji fall back to hex encoding the whole thing
+fn conf_escape(raw: &str) -> String {
+    if raw.bytes().all(|b| b.is_ascii_graphic() && b != b'"') {
+        format!("\"{raw}\"")
+    } else {
+        hex::encode(raw)
     }
 }
 

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -16,43 +16,63 @@ pub struct ScanResult {
 }
 
 impl ScanResult {
+    fn from_line(line: &str) -> Option<Self> {
+        let (mac, rest) = line.split_once('\t')?;
+        let (frequency, rest) = rest.split_once('\t')?;
+        let (signal, rest) = rest.split_once('\t')?;
+        let signal = isize::from_str(signal).ok()?;
+        let (flags, escaped_name) = rest.split_once('\t')?;
+        let mut bytes = escaped_name.as_bytes().iter().copied();
+        let mut name = vec![];
+        // undo "printf_encode"
+        loop {
+            name.push(match bytes.next() {
+                Some(b'\\') => match bytes.next()? {
+                    b'n' => b'\n',
+                    b'r' => b'\r',
+                    b't' => b'\t',
+                    b'e' => b'\x1b',
+                    b'x' => {
+                        let hex = [bytes.next()?, bytes.next()?];
+                        u8::from_str_radix(std::str::from_utf8(&hex).ok()?, 16).ok()?
+                    }
+                    c => c,
+                },
+                Some(c) => c,
+                None => break,
+            })
+        }
+        let name = String::from_utf8(name).ok()?;
+        Some(ScanResult {
+            mac: mac.to_string(),
+            frequency: frequency.to_string(),
+            signal,
+            flags: flags.to_string(),
+            name,
+        })
+    }
+
+    // Overide to allow tabs in the raw string to avoid double escaping everything
+    #[allow(clippy::tabs_in_doc_comments)]
+    /// Parses lines from a scan result
+    ///```
+    ///use wifi_ctrl::sta::ScanResult;
+    ///let results = ScanResult::vec_from_str(r#"bssid / frequency / signal level / flags / ssid
+    ///00:5f:67:90:da:64	2417	-35	[WPA-PSK-CCMP][WPA2-PSK-CCMP][ESS]	TP-Link DA64
+    ///e0:91:f5:7d:11:c0	2462	-33	[WPA2-PSK-CCMP][WPS][ESS]	¯\\_(\xe3\x83\x84)_/¯
+    ///"#).unwrap();
+    ///assert_eq!(results[0].mac, "00:5f:67:90:da:64");
+    ///assert_eq!(results[0].name, "TP-Link DA64");
+    ///assert_eq!(results[1].signal, -33);
+    ///assert_eq!(results[1].name, r#"¯\_(ツ)_/¯"#);
+    ///```
     pub fn vec_from_str(response: &str) -> Result<Vec<ScanResult>> {
         let mut results = Vec::new();
-        let split = response.split('\n').skip(1);
-        for line in split {
-            let mut line_split = line.split_whitespace();
-            if let (Some(mac), Some(frequency), Some(signal), Some(flags)) = (
-                line_split.next(),
-                line_split.next(),
-                line_split.next(),
-                line_split.next(),
-            ) {
-                let mut name: Option<String> = None;
-                for text in line_split {
-                    match &mut name {
-                        Some(started) => {
-                            started.push(' ');
-                            started.push_str(text);
-                        }
-                        None => {
-                            name = Some(text.to_string());
-                        }
-                    }
-                }
-                if let Some(name) = name {
-                    if let Ok(signal) = isize::from_str(signal) {
-                        let scan_result = ScanResult {
-                            mac: mac.to_string(),
-                            frequency: frequency.to_string(),
-                            signal,
-                            flags: flags.to_string(),
-                            name,
-                        };
-                        results.push(scan_result);
-                    } else {
-                        warn!("Invalid string for signal: {signal}");
-                    }
-                }
+        for line in response.lines().skip(1) {
+            if let Some(scan_result) = ScanResult::from_line(line) {
+                results.push(scan_result);
+            } else {
+                warn!("Invalid result from scan: {line}");
             }
         }
         Ok(results)


### PR DESCRIPTION
The corresponding c code for encoding and decoding them can be found in wpa_supplicant/src/utils/common.c

printf_decode escapes a SSID for returning in scan results

wpa_config_parse_string reads a string from the config or the socket. It might be nicer to use the printf encoded P"I \xf0\x9f\xa6\x80 rust" style but I could not find a decent encoder.