### PR TITLE
Fix clippy failure from newer stable toolchain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub type Result<T = ()> = std::result::Result<T, error::ClientError>;
 pub type SocketResult<T = ()> = std::result::Result<T, error::SocketError>;
 pub type ParseResult<T = ()> = std::result::Result<T, error::ParseError>;
 
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 
 pub(crate) trait ShutdownSignal {
     fn is_shutdown(&self) -> bool;

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -54,7 +54,7 @@ impl ScanResult {
         for line in response.lines().skip(1) {
             results.push(ScanResult::from_line(line).ok_or(ParseError::ScanResult)?);
         }
-        results.sort_by(|a, b| a.signal.cmp(&b.signal));
+        results.sort_by_key(|a| a.signal);
         Ok(Arc::new(results))
     }
 }


### PR DESCRIPTION
CI's Clippy step (`--all-features -- -Dclippy::all`) started failing on `main` without a related code change. The runner pins `toolchain: stable`, and newer stable Clippy (1.96.0) now flags the `sort_by`/`cmp` pattern under `unnecessary_sort_by`, which is promoted to an error by `-Dclippy::all`.

## Changes
- `src/sta/types.rs`: `sort_by(|a, b| a.signal.cmp(&b.signal))` → `sort_by_key(|a| a.signal)`
- `src/lib.rs`: drop the now-unused `error` import (cleared a lingering `unused_imports` warning)

## Verification
Ran the full CI job locally:
- `cargo clippy --all-features -- -Dclippy::all` — clean
- `cargo fmt -- --check` — passes
- `cargo test` — 5 unit + 3 doc-tests pass