### PR TITLE
Fix correctness issues from the error-handling refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wifi-ctrl"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 description = "Tokio-based runtimes for communicating with hostapd and wpa-supplicant"

--- a/examples/wifi-ap.rs
+++ b/examples/wifi-ap.rs
@@ -11,7 +11,7 @@ async fn main() -> Result {
     info!("Starting wifi-ap example");
 
     let mut network_interfaces = NetworkInterface::show().unwrap();
-    network_interfaces.sort_by(|a, b| a.index.cmp(&b.index));
+    network_interfaces.sort_by_key(|itf| itf.index);
     for (i, itf) in network_interfaces.iter().enumerate() {
         info!("[{:?}] {:?}", i, itf.name);
     }

--- a/examples/wifi-sta.rs
+++ b/examples/wifi-sta.rs
@@ -11,12 +11,15 @@ async fn main() -> Result {
     info!("Starting wifi-sta example");
 
     let mut network_interfaces = NetworkInterface::show().unwrap();
-    network_interfaces.sort_by(|a, b| a.index.cmp(&b.index));
+    network_interfaces.sort_by_key(|itf| itf.index);
     for (i, itf) in network_interfaces.iter().enumerate() {
         info!("[{:?}] {:?}", i, itf.name);
     }
     let user_input = read_until_break().await;
-    let index = user_input.trim().parse::<usize>().expect("");
+    let index = user_input
+        .trim()
+        .parse::<usize>()
+        .expect("user should enter a number");
     let mut setup = sta::WifiSetup::new();
 
     let proposed_path = format!("/var/run/wpa_supplicant/{}", network_interfaces[index].name);

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -79,7 +79,7 @@ impl WifiAp {
                 request = self.request_receiver.recv() => EventOrRequest::Request(request),
             );
             match event_or_request {
-                EventOrRequest::Event(event) => self.handle_event(&mut socket_handle, event).await,
+                EventOrRequest::Event(event) => self.handle_event(event),
                 EventOrRequest::Request(request) => match request {
                     Some(Request::Shutdown) => return Ok(()),
                     Some(request) => Self::handle_request(&mut socket_handle, request).await?,
@@ -89,11 +89,7 @@ impl WifiAp {
         }
     }
 
-    async fn handle_event<const N: usize>(
-        &self,
-        _socket_handle: &mut SocketHandle<N>,
-        event_msg: Event,
-    ) {
+    fn handle_event(&self, event_msg: Event) {
         match event_msg {
             Event::ApStaConnected(mac) => self.broadcast(Broadcast::Connected(mac)),
             Event::ApStaDisconnected(mac) => self.broadcast(Broadcast::Disconnected(mac)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,10 @@ use std::convert::Infallible;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::oneshot::error::RecvError;
-#[derive(Error, Debug)]
 
 /// Error returned by [access point](crate::ap::WifiAp::run) and [station](crate::sta::WifiStation::run) runners if there is
-/// problem with the control socket. e.g. if `wpa_suplicant` is restarted
+/// a problem with the control socket. e.g. if `wpa_supplicant` is restarted
+#[derive(Error, Debug)]
 pub enum SocketError {
     /// IO error from control socket
     #[error("io error: {0}")]
@@ -26,13 +26,13 @@ pub enum SocketError {
 }
 
 /// Error returned by [access point](crate::ap::RequestClient) and [station](crate::sta::RequestClient) clients if there is
-/// problem with the request e.g. asking to select a network you have not created a config for
+/// a problem with the request e.g. asking to select a network you have not created a config for
 #[derive(Error, Debug, Clone)]
 pub enum ClientError {
     /// Request failed  e.g. asking to select a network you have not created a config for
     #[error("Supplicant reported request failed")]
     Failed,
-    /// Error parsing the reponse from the socket. This is probably a bug in the [`wifi_ctrl`](crate) code.
+    /// Error parsing the response from the socket. This is probably a bug in the [`wifi_ctrl`](crate) code.
     #[error("error {error} parsing response: \n{failed_response}")]
     ParsingResponse {
         #[source]
@@ -42,17 +42,18 @@ pub enum ClientError {
     /// Timeout waiting for response to request on control socket
     #[error("timeout waiting for response")]
     Timeout,
-    /// Request was too big to fit in a datagram, mostlikely seen on bad custom requests
+    /// Request was too big to fit in a datagram, most likely seen on bad custom requests
     #[error("Request was too big only sent {0} of {1} bytes")]
     DidNotWriteAllBytes(usize, usize),
     /// The control socket is not connected at the moment, reconnect and try again
-    #[error("Runner task not runnning")]
+    #[error("Runner task not running")]
     RunnerNotRunning,
+    /// A select request is already pending; wait for it to resolve before selecting again
     #[error("Select already pending")]
     PendingSelect,
 }
 
-/// A sub error of [`ClientError`] returned when there is a problem parsing the reponse from
+/// A sub error of [`ClientError`] returned when there is a problem parsing the response from
 /// the socket. This is probably a bug in the [`wifi_ctrl`](crate) code.
 #[derive(Error, Debug, Clone)]
 pub enum ParseError {
@@ -81,7 +82,7 @@ impl<T> From<SendError<T>> for ClientError {
     }
 }
 
-// Happens when the runner half of a repsonse channel gets dropped
+// Happens when the runner half of a response channel gets dropped
 // e.g. if it is asked to shut down, or the socket dies
 impl From<RecvError> for ClientError {
     fn from(_: RecvError) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,8 +58,6 @@ pub enum ClientError {
 pub enum ParseError {
     #[error("Didn't get expected literal \"OK\" response")]
     NotOK,
-    #[error("Too few columns in scan response")]
-    ScanResult,
     #[error("error parsing config: {0}")]
     ParseConfig(#[from] config::ConfigError),
     #[error("error parsing int: {0}")]

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -84,11 +84,32 @@ impl<const N: usize> SocketHandle<N> {
     }
 
     pub async fn command(&mut self, cmd: &[u8]) -> SocketResult<Result> {
+        self.command_matching(cmd, |data| data == "OK").await
+    }
+
+    /// Like [`Self::command`] but with a custom set of accepted responses,
+    /// for commands whose success reply isn't just "OK".
+    pub async fn command_matching(
+        &mut self,
+        cmd: &[u8],
+        accept: impl Fn(&str) -> bool,
+    ) -> SocketResult<Result> {
         let n = self.socket.send(cmd).await?;
         if n != cmd.len() {
             return Ok(Err(error::ClientError::DidNotWriteAllBytes(n, cmd.len())));
         }
-        self.expect_ok_with_default_timeout().await
+        let parse = |data: &str| {
+            if accept(data) {
+                Ok(())
+            } else {
+                Err(error::ParseError::NotOK)
+            }
+        };
+        tokio::select!(
+            resp = self.parse_resp(parse) => resp,
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) =>
+                Ok(Err(error::ClientError::Timeout)),
+        )
     }
 
     pub(crate) async fn request<'a, T, E, F>(
@@ -129,31 +150,4 @@ impl<const N: usize> SocketHandle<N> {
             }))
     }
 
-    async fn expect_ok(&mut self) -> SocketResult<Result> {
-        self.parse_resp(|data| {
-            // Scan (and only scan) return FAIL-BUSY when already scanning
-            if data == "OK" || data == "FAIL-BUSY" {
-                Ok(())
-            } else {
-                Err(error::ParseError::NotOK)
-            }
-        })
-        .await
-    }
-
-    async fn expect_ok_with_default_timeout(&mut self) -> SocketResult<Result> {
-        self.expect_ok_with_timeout(tokio::time::Duration::from_secs(1))
-            .await
-    }
-
-    pub async fn expect_ok_with_timeout(
-        &mut self,
-        timeout: tokio::time::Duration,
-    ) -> SocketResult<Result> {
-        tokio::select!(
-            resp = self.expect_ok() => resp,
-            _ =
-                tokio::time::sleep(timeout) => Ok(Err(error::ClientError::Timeout))
-        )
-    }
 }

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -149,5 +149,4 @@ impl<const N: usize> SocketHandle<N> {
                 }
             }))
     }
-
 }

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -41,7 +41,6 @@ pub(crate) enum Request {
     Status(oneshot::Sender<Result<Status>>),
     Networks(oneshot::Sender<Result<Vec<NetworkResult>>>),
     Scan(oneshot::Sender<Result<ScanResults>>),
-    ScanResults,
     AddNetwork(oneshot::Sender<Result<usize>>),
     SetNetwork(usize, SetNetwork, oneshot::Sender<Result>),
     SaveConfig(oneshot::Sender<Result>),

--- a/src/sta/event_socket.rs
+++ b/src/sta/event_socket.rs
@@ -50,7 +50,7 @@ impl EventSocket {
             {
                 Event::WrongPsk
             } else {
-                Event::Unknown(data_str.into())
+                Event::Unknown(data_str.trim_end().into())
             },
         )
     }

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -260,15 +260,21 @@ impl WifiStation {
                             let _ = response_sender.send(Err(e));
                         } else {
                             debug!("wpa_ctrl selected network {id}");
-                            let status = Self::get_status(socket_handle).await?.unwrap_or_default();
-                            if status.get("id") == Some(&id.to_string()) {
-                                let _ = response_sender.send(Ok(SelectResult::AlreadyConnected));
-                            } else {
-                                *select_request = Some(SelectRequest::new(
-                                    self.self_sender.clone(),
-                                    response_sender,
-                                    self.select_timeout,
-                                ));
+                            match Self::get_status(socket_handle).await? {
+                                Err(e) => {
+                                    let _ = response_sender.send(Err(e));
+                                }
+                                Ok(status) if status.get("id") == Some(&id.to_string()) => {
+                                    let _ =
+                                        response_sender.send(Ok(SelectResult::AlreadyConnected));
+                                }
+                                Ok(_) => {
+                                    *select_request = Some(SelectRequest::new(
+                                        self.self_sender.clone(),
+                                        response_sender,
+                                        self.select_timeout,
+                                    ));
+                                }
                             }
                         }
                     }

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -1,5 +1,3 @@
-use core::str;
-
 use crate::error::ClientError;
 
 use super::*;
@@ -50,7 +48,10 @@ impl WifiStation {
             EventSocket::new(&self.socket_path, &mut self.request_receiver).await?;
         deferred_requests.extend(next_deferred_requests);
         for request in deferred_requests {
-            let _ = self.self_sender.send(request).await;
+            self.self_sender
+                .send(request)
+                .await
+                .expect("self_sender should never close as same struct owns both ends");
         }
         self.broadcast(Broadcast::Ready);
         self.run_internal(unsolicited, socket_handle).await

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -88,8 +88,13 @@ impl WifiStation {
             match event_or_request {
                 EventOrRequest::Event(unsolicited_msg) => {
                     debug!("Unsolicited event: {unsolicited_msg:?}");
-                    self.handle_event(unsolicited_msg, &mut scan_requests, &mut select_request)
-                        .await
+                    self.handle_event(
+                        &mut socket_handle,
+                        unsolicited_msg,
+                        &mut scan_requests,
+                        &mut select_request,
+                    )
+                    .await?
                 }
                 EventOrRequest::Request(request) => match request {
                     Some(Request::Shutdown) => return Ok(()),
@@ -108,15 +113,21 @@ impl WifiStation {
         }
     }
 
-    async fn handle_event(
+    async fn handle_event<const N: usize>(
         &mut self,
+        socket_handle: &mut SocketHandle<N>,
         event: Event,
         scan_requests: &mut Vec<oneshot::Sender<Result<Arc<Vec<ScanResult>>>>>,
         select_request: &mut Option<SelectRequest>,
-    ) {
+    ) -> SocketResult {
         match event {
             Event::ScanComplete => {
-                let _ = self.self_sender.send(Request::ScanResults).await;
+                let scan_results = socket_handle
+                    .request("SCAN_RESULTS", ScanResult::vec_from_str)
+                    .await?;
+                while let Some(scan_request) = scan_requests.pop() {
+                    let _ = scan_request.send(scan_results.clone());
+                }
             }
             Event::ScanFailed => {
                 while let Some(scan_request) = scan_requests.pop() {
@@ -148,6 +159,7 @@ impl WifiStation {
                 self.broadcast(Broadcast::Unknown(msg));
             }
         }
+        Ok(())
     }
 
     async fn get_status<const N: usize>(
@@ -184,14 +196,6 @@ impl WifiStation {
                         let _ = response_channel.send(Err(e));
                     }
                 };
-            }
-            Request::ScanResults => {
-                let scan_results = socket_handle
-                    .request("SCAN_RESULTS", ScanResult::vec_from_str)
-                    .await?;
-                while let Some(scan_request) = scan_requests.pop() {
-                    let _ = scan_request.send(scan_results.clone());
-                }
             }
             Request::Networks(response_channel) => {
                 let network_list = NetworkResult::request_results(socket_handle).await?;

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -188,7 +188,13 @@ impl WifiStation {
                 }
             }
             Request::Scan(response_channel) => {
-                match socket_handle.command(b"SCAN").await? {
+                // wpa_supplicant replies FAIL-BUSY when a scan is already in
+                // progress; the pending CTRL-EVENT-SCAN-RESULTS will answer
+                // this request too, so treat it as accepted
+                match socket_handle
+                    .command_matching(b"SCAN", |data| data == "OK" || data == "FAIL-BUSY")
+                    .await?
+                {
                     Ok(_) => {
                         scan_requests.push(response_channel);
                     }

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -1,4 +1,3 @@
-use super::error::ParseError;
 use super::{config, config::unprintf, warn, Result, SocketHandle};
 use super::{ParseResult, SocketResult};
 
@@ -52,7 +51,13 @@ impl ScanResult {
     pub fn vec_from_str(response: &str) -> ParseResult<Arc<Vec<ScanResult>>> {
         let mut results = Vec::new();
         for line in response.lines().skip(1) {
-            results.push(ScanResult::from_line(line).ok_or(ParseError::ScanResult)?);
+            // skip lines we can't parse so one odd entry doesn't fail the
+            // whole scan
+            if let Some(scan_result) = ScanResult::from_line(line) {
+                results.push(scan_result);
+            } else {
+                warn!("Invalid result from scan: {line}");
+            }
         }
         results.sort_by_key(|a| a.signal);
         Ok(Arc::new(results))


### PR DESCRIPTION
Follow-ups to the error-handling refactor (#16), addressing the review findings:

- **Fix a self-send deadlock on scan completion**: `handle_event` sent `Request::ScanResults` into the runner's own request channel and awaited it; with the channel full, the runner would block on its own queue forever. `SCAN_RESULTS` is now fetched inline (as before the refactor) and the `Request::ScanResults` variant is gone.
- **Scope FAIL-BUSY to SCAN**: `expect_ok` accepted `FAIL-BUSY` as success for every command (`SET_NETWORK`, `SAVE_CONFIG`, `ENABLE`, `ATTACH`, ...). `command` is now strict about `OK`; a new `command_matching` lets the SCAN handler accept `FAIL-BUSY`, where the pending scan-results event answers the request anyway.
- **Don't fail the whole scan on one bad line**: restore skip-with-warn per line in `ScanResult::vec_from_str` so a single odd AP entry can't make scanning unusable.
- **Report STATUS parse failure to the SelectNetwork requester** instead of `unwrap_or_default()`, which silently lost `AlreadyConnected` detection and left the select to die by timeout.
- Assorted cleanups: unused imports/params, example clippy lints, typos, doc comments, trailing newline on `Broadcast::Unknown`.
- **Bump version to 0.3.0** — the refactor is semver-breaking (error types split, `run(&mut self)`, `WifiSetup::new()` no longer returns `Result`, `SelectResult` variants removed, parse fn signatures changed).