### PR TITLE
Drop tokio rt feature by folding select timeout into event loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "0" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 tempfile = "3"
-tokio = { version = "1", default-features = false, features = ["net",  "rt", "sync", "macros", "time"] }
+tokio = { version = "1", default-features = false, features = ["net", "sync", "macros", "time"] }
 
 [dev-dependencies]
 env_logger = "0"

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -48,7 +48,6 @@ pub(crate) enum Request {
     RemoveNetwork(RemoveNetwork, oneshot::Sender<Result>),
     SelectNetwork(usize, oneshot::Sender<Result<SelectResult>>),
     Shutdown,
-    SelectTimeout,
 }
 
 impl ShutdownSignal for Request {

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -70,11 +70,12 @@ impl WifiStation {
     ) -> SocketResult {
         // We will collect scan requests and batch respond to them when results are ready
         let mut scan_requests = Vec::new();
-        let mut select_request = None;
+        let mut select_request: Option<SelectRequest> = None;
         loop {
             enum EventOrRequest {
                 Event(Event),
                 Request(Option<Request>),
+                SelectTimeout,
             }
 
             let event_or_request = tokio::select!(
@@ -84,6 +85,12 @@ impl WifiStation {
                 request = self.request_receiver.recv() => {
                     EventOrRequest::Request(request)
                 },
+                _ = async {
+                    match select_request.as_mut() {
+                        Some(select_request) => select_request.timeout.as_mut().await,
+                        None => std::future::pending().await,
+                    }
+                } => EventOrRequest::SelectTimeout,
             );
 
             match event_or_request {
@@ -110,6 +117,11 @@ impl WifiStation {
                     }
                     None => return Err(error::SocketError::ClientChannelClosed),
                 },
+                EventOrRequest::SelectTimeout => {
+                    if let Some(sender) = select_request.take() {
+                        sender.send(Err(ClientError::Timeout));
+                    }
+                }
             }
         }
     }
@@ -182,11 +194,6 @@ impl WifiStation {
                 let data_str = socket_handle.request(&custom, TryInto::try_into).await?;
                 debug!("Custom request response: {data_str:?}");
                 let _ = response_channel.send(data_str);
-            }
-            Request::SelectTimeout => {
-                if let Some(sender) = select_request.take() {
-                    sender.send(Err(ClientError::Timeout));
-                }
             }
             Request::Scan(response_channel) => {
                 // wpa_supplicant replies FAIL-BUSY when a scan is already in
@@ -271,7 +278,6 @@ impl WifiStation {
                                 }
                                 Ok(_) => {
                                     *select_request = Some(SelectRequest::new(
-                                        self.self_sender.clone(),
                                         response_sender,
                                         self.select_timeout,
                                     ));
@@ -304,26 +310,20 @@ fn conf_escape(raw: &str) -> String {
 
 struct SelectRequest {
     response: oneshot::Sender<Result<SelectResult>>,
-    timeout: tokio::task::JoinHandle<()>,
+    /// Polled as a branch of the main event loop; expiry resolves the request
+    /// with a timeout error
+    timeout: std::pin::Pin<Box<tokio::time::Sleep>>,
 }
 
 impl SelectRequest {
-    fn new(
-        sender: mpsc::Sender<Request>,
-        response: oneshot::Sender<Result<SelectResult>>,
-        timeout: Duration,
-    ) -> Self {
+    fn new(response: oneshot::Sender<Result<SelectResult>>, timeout: Duration) -> Self {
         Self {
             response,
-            timeout: tokio::task::spawn(async move {
-                tokio::time::sleep(timeout).await;
-                let _ = sender.send(Request::SelectTimeout).await;
-            }),
+            timeout: Box::pin(tokio::time::sleep(timeout)),
         }
     }
 
     fn send(self, result: Result<SelectResult>) {
-        self.timeout.abort();
         let _ = self.response.send(result);
     }
 }


### PR DESCRIPTION
## What

Removes the library's only `tokio::task::spawn` and drops `rt` from the tokio feature set. The crate now only needs `net`, `sync`, `time`, and `macros` — it never spawns tasks, it just needs a reactor to be polled on.

## How

- `SelectRequest` holds a `Pin<Box<tokio::time::Sleep>>` instead of a spawned task's `JoinHandle`. The station's main event loop races it as a third `select!` branch when a select request is pending (parks on `future::pending()` otherwise), resolving the request with `ClientError::Timeout` on expiry.
- `Request::SelectTimeout` is removed — the timeout no longer round-trips through the mpsc request channel, so it can't queue behind other pending requests and fires exactly on time.

## Testing

- `cargo build`, `cargo clippy --all-targets`, `cargo test` (unit + doc tests) all pass
- `cargo tree -e features -i tokio --edges no-dev` confirms `rt` is gone from the dependency graph