### PR TITLE
pin deps, declare MSRV, and fix typos/docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,22 @@ license = "Apache-2.0"
 repository = "https://github.com/novalabsxyz/wifi-ctrl"
 readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
+rust-version = "1.64"
 
 [dependencies]
 hex = "0.4"
-log = { version = "0" }
+log = { version = "0.4" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["net",  "rt", "sync", "macros", "time"] }
 
 [dev-dependencies]
-env_logger = "0"
+env_logger = "0.11"
 network-interface = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "io-std", "io-util"] }
-tokio-util  ={ version = "0", features = ["codec"] }
-futures = "0"
+tokio-util  ={ version = "0.7", features = ["codec"] }
+futures = "0.3"
+
+[lints.rust]
+unsafe_code = "warn"

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,12 +10,12 @@ type Result<T> = std::result::Result<T, ConfigError>;
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
 pub enum ConfigError {
     #[error("Missing '=' delimiter in config line")]
-    MissingDelimterEqual,
+    MissingDelimiterEqual,
     #[error("escape code is not made up of valid hex code")]
     InvalidEscape,
     #[error("escape code is incomplete")]
     IncompleteEscape,
-    #[error("escaped value is not valid uft8 after unescaping")]
+    #[error("escaped value is not valid utf8 after unescaping")]
     NonUtf8Escape,
     #[error("Value could not be decoded")]
     SerdeError(String),
@@ -61,7 +61,7 @@ where
     for line in s.trim().lines() {
         let (k, v) = line
             .split_once('=')
-            .ok_or(ConfigError::MissingDelimterEqual)?;
+            .ok_or(ConfigError::MissingDelimiterEqual)?;
         let (k, i) = if let Some((k, i)) = k.split_once('[') {
             if let Some((i, "")) = i.rsplit_once(']') {
                 (k, i.parse().map_err(ConfigError::custom)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/wpactrl/"
+    html_root_url = "https://docs.rs/wifi-ctrl/"
 )]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -282,7 +282,9 @@ impl WifiStation {
                     Some(_) => {
                         warn!("Select request already pending! Dropping this one.");
                         let _ = response_sender.send(Err(ClientError::PendingSelect));
-                        debug!("wpa_ctrl removed network {id}");
+                        debug!(
+                            "wpa_ctrl rejected select of network {id}: a select is already pending"
+                        );
                     }
                 };
             }


### PR DESCRIPTION
- Pin loose "0" version reqs to real minor lines (log 0.4, env_logger 0.11, tokio-util 0.7, futures 0.3).
- Declare rust-version = "1.64" and add unsafe_code = "warn".
- Correct html_root_url crate name (wpactrl -> wifi-ctrl).
- Rename ConfigError::MissingDelimterEqual -> MissingDelimiterEqual and fix the "utf8" error text.
- Fix a misleading select-already-pending debug log.

Note: renaming the public ConfigError variant is a minor breaking change.