### PR TITLE
add control-socket timeouts and bound attach retries

### DIFF
--- a/src/ap/event_socket.rs
+++ b/src/ap/event_socket.rs
@@ -2,12 +2,6 @@ use super::*;
 
 use std::time::Duration;
 
-/// Maximum number of attempts for the `ATTACH`/`LOG_LEVEL` handshake before
-/// giving up. With [`ATTACH_RETRY_DELAY`] between tries this bounds the wait to
-/// roughly a minute, unlike the socket-open path which retries for 5 minutes.
-const ATTACH_RETRIES: usize = 240;
-const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(250);
-
 pub(crate) struct EventSocket {
     socket_handle: SocketHandle<1024>,
 }
@@ -25,6 +19,8 @@ impl EventSocket {
         request_receiver: &mut mpsc::Receiver<Request>,
         attach_options: &[String],
         command_timeout: Duration,
+        attach_retries: usize,
+        attach_retry_delay: Duration,
     ) -> SocketResult<(Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
@@ -42,8 +38,20 @@ impl EventSocket {
             command.push(' ');
             command.push_str(o);
         }
-        retry_command(&mut socket_handle, command.as_bytes()).await?;
-        retry_command(&mut socket_handle, b"LOG_LEVEL DEBUG").await?;
+        retry_command(
+            &mut socket_handle,
+            command.as_bytes(),
+            attach_retries,
+            attach_retry_delay,
+        )
+        .await?;
+        retry_command(
+            &mut socket_handle,
+            b"LOG_LEVEL DEBUG",
+            attach_retries,
+            attach_retry_delay,
+        )
+        .await?;
         info!("hostapd event stream registered");
         Ok((deferred_requests, Self { socket_handle }))
     }
@@ -66,17 +74,19 @@ impl EventSocket {
 }
 
 /// Send a control command, retrying on failure with a fixed delay up to
-/// [`ATTACH_RETRIES`] times. Returns [`SocketError::AttachFailed`] once the
-/// attempts are exhausted so the runtime doesn't spin forever.
+/// `retries` times. Returns [`SocketError::AttachFailed`] once the attempts are
+/// exhausted so the runtime doesn't spin forever.
 async fn retry_command<const N: usize>(
     socket_handle: &mut SocketHandle<N>,
     command: &[u8],
+    retries: usize,
+    delay: Duration,
 ) -> SocketResult {
-    for _ in 0..ATTACH_RETRIES {
+    for _ in 0..retries {
         if socket_handle.command(command).await?.is_ok() {
             return Ok(());
         }
-        tokio::time::sleep(ATTACH_RETRY_DELAY).await;
+        tokio::time::sleep(delay).await;
     }
     Err(error::SocketError::AttachFailed(
         String::from_utf8_lossy(command).to_string(),

--- a/src/ap/event_socket.rs
+++ b/src/ap/event_socket.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+use std::time::Duration;
+
+/// Maximum number of attempts for the `ATTACH`/`LOG_LEVEL` handshake before
+/// giving up. With [`ATTACH_RETRY_DELAY`] between tries this bounds the wait to
+/// roughly a minute, unlike the socket-open path which retries for 5 minutes.
+const ATTACH_RETRIES: usize = 240;
+const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(250);
+
 pub(crate) struct EventSocket {
     socket_handle: SocketHandle<1024>,
 }
@@ -16,29 +24,26 @@ impl EventSocket {
         socket: P,
         request_receiver: &mut mpsc::Receiver<Request>,
         attach_options: &[String],
+        command_timeout: Duration,
     ) -> SocketResult<(Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
     {
-        let (mut socket_handle, deferred_requests) =
-            SocketHandle::open(socket, "hostapd_async.sock", request_receiver).await?;
+        let (mut socket_handle, deferred_requests) = SocketHandle::open(
+            socket,
+            "hostapd_async.sock",
+            request_receiver,
+            command_timeout,
+        )
+        .await?;
 
         let mut command = "ATTACH".to_string();
         for o in attach_options {
             command.push(' ');
             command.push_str(o);
         }
-        let mut attach = socket_handle.command(command.as_bytes()).await?;
-        while attach.is_err() {
-            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
-            attach = socket_handle.command(command.as_bytes()).await?;
-        }
-
-        let mut log_level = socket_handle.command(b"LOG_LEVEL DEBUG").await?;
-        while log_level.is_err() {
-            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
-            log_level = socket_handle.command(b"LOG_LEVEL DEBUG").await?;
-        }
+        retry_command(&mut socket_handle, command.as_bytes()).await?;
+        retry_command(&mut socket_handle, b"LOG_LEVEL DEBUG").await?;
         info!("hostapd event stream registered");
         Ok((deferred_requests, Self { socket_handle }))
     }
@@ -58,4 +63,22 @@ impl EventSocket {
             Event::Unknown(data_str.to_string())
         })
     }
+}
+
+/// Send a control command, retrying on failure with a fixed delay up to
+/// [`ATTACH_RETRIES`] times. Returns [`SocketError::AttachFailed`] once the
+/// attempts are exhausted so the runtime doesn't spin forever.
+async fn retry_command<const N: usize>(
+    socket_handle: &mut SocketHandle<N>,
+    command: &[u8],
+) -> SocketResult {
+    for _ in 0..ATTACH_RETRIES {
+        if socket_handle.command(command).await?.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(ATTACH_RETRY_DELAY).await;
+    }
+    Err(error::SocketError::AttachFailed(
+        String::from_utf8_lossy(command).to_string(),
+    ))
 }

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -28,6 +28,10 @@ pub struct WifiAp {
     self_sender: mpsc::Sender<Request>,
     /// How long to wait for a reply to a control command/request
     command_timeout: std::time::Duration,
+    /// How many times to retry the ATTACH/LOG_LEVEL handshake before giving up
+    attach_retries: usize,
+    /// How long to wait between attach handshake attempts
+    attach_retry_delay: std::time::Duration,
 }
 
 impl WifiAp {
@@ -38,6 +42,8 @@ impl WifiAp {
             &mut self.request_receiver,
             &self.attach_options,
             self.command_timeout,
+            self.attach_retries,
+            self.attach_retry_delay,
         )
         .await?;
         // We start up a separate socket for receiving the "unexpected" events that

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -22,11 +22,12 @@ pub struct WifiAp {
     attach_options: Vec<String>,
     /// Channel for receiving requests
     request_receiver: mpsc::Receiver<Request>,
-    #[allow(unused)]
     /// Channel for broadcasting alerts
     broadcast_sender: broadcast::Sender<Broadcast>,
     /// Channel for sending requests to itself
     self_sender: mpsc::Sender<Request>,
+    /// How long to wait for a reply to a control command/request
+    command_timeout: std::time::Duration,
 }
 
 impl WifiAp {
@@ -36,6 +37,7 @@ impl WifiAp {
             &self.socket_path,
             &mut self.request_receiver,
             &self.attach_options,
+            self.command_timeout,
         )
         .await?;
         // We start up a separate socket for receiving the "unexpected" events that
@@ -44,6 +46,7 @@ impl WifiAp {
             &self.socket_path,
             "mapper_hostapd_sync.sock",
             &mut self.request_receiver,
+            self.command_timeout,
         )
         .await?;
         deferred_requests.extend(next_deferred_requests);

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -7,6 +7,13 @@ use std::time::Duration;
 /// unblocking the single-task runtime if a reply never arrives.
 const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Default number of `ATTACH`/`LOG_LEVEL` handshake attempts. With
+/// [`DEFAULT_ATTACH_RETRY_DELAY`] between tries this bounds the wait to roughly
+/// a minute, unlike the socket-open path which retries for 5 minutes.
+const DEFAULT_ATTACH_RETRIES: usize = 240;
+/// Default delay between attach handshake attempts.
+const DEFAULT_ATTACH_RETRY_DELAY: Duration = Duration::from_millis(250);
+
 /// A convenient default type for setting up the WiFiAp process.
 pub type WifiSetup = WifiSetupGeneric<32, 32>;
 
@@ -38,6 +45,8 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 broadcast_sender,
                 self_sender,
                 command_timeout: DEFAULT_COMMAND_TIMEOUT,
+                attach_retries: DEFAULT_ATTACH_RETRIES,
+                attach_retry_delay: DEFAULT_ATTACH_RETRY_DELAY,
             },
             request_client,
             broadcast_receiver,
@@ -58,6 +67,18 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     /// giving up with [`ClientError::Timeout`](crate::error::ClientError::Timeout).
     pub fn set_command_timeout(&mut self, timeout: Duration) {
         self.wifi.command_timeout = timeout;
+    }
+
+    /// Set how many times to retry the hostapd `ATTACH`/`LOG_LEVEL` handshake
+    /// before giving up with
+    /// [`SocketError::AttachFailed`](crate::error::SocketError::AttachFailed).
+    pub fn set_attach_retries(&mut self, retries: usize) {
+        self.wifi.attach_retries = retries;
+    }
+
+    /// Set how long to wait between attach handshake attempts.
+    pub fn set_attach_retry_delay(&mut self, delay: Duration) {
+        self.wifi.attach_retry_delay = delay;
     }
 
     pub fn get_broadcast_receiver(&self) -> BroadcastReceiver {

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+use std::time::Duration;
+
+/// Default time to wait for a reply to a control command/request before giving
+/// up. Chosen to comfortably cover slower hostapd operations while still
+/// unblocking the single-task runtime if a reply never arrives.
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// A convenient default type for setting up the WiFiAp process.
 pub type WifiSetup = WifiSetupGeneric<32, 32>;
 
@@ -30,6 +37,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 request_receiver,
                 broadcast_sender,
                 self_sender,
+                command_timeout: DEFAULT_COMMAND_TIMEOUT,
             },
             request_client,
             broadcast_receiver,
@@ -44,6 +52,12 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
         for o in options {
             self.wifi.attach_options.push(o.to_string());
         }
+    }
+
+    /// Set how long to wait for a reply to a control command/request before
+    /// giving up with [`ClientError::Timeout`](crate::error::ClientError::Timeout).
+    pub fn set_command_timeout(&mut self, timeout: Duration) {
+        self.wifi.command_timeout = timeout;
     }
 
     pub fn get_broadcast_receiver(&self) -> BroadcastReceiver {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,9 @@ pub enum SocketError {
     /// Permission denied opening control socket
     #[error("permission denied opening socket {0}")]
     PermissionDeniedOpeningSocket(String),
+    /// A control command kept failing while registering the event stream, even after retrying
+    #[error("gave up retrying command {0} while attaching to event stream")]
+    AttachFailed(String),
 }
 
 /// Error returned by [access point](crate::ap::RequestClient) and [station](crate::sta::RequestClient) clients if there is

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -1,6 +1,7 @@
 use super::*;
 use error::{ClientError, ParseError};
 use std::io::ErrorKind;
+use std::time::Duration;
 use tokio::net::UnixDatagram;
 
 pub struct SocketHandle<const N: usize> {
@@ -10,6 +11,8 @@ pub struct SocketHandle<const N: usize> {
     /// Socket for synchronous messages
     pub socket: UnixDatagram,
     pub buffer: [u8; N],
+    /// How long to wait for a reply before giving up on a command/request
+    command_timeout: Duration,
 }
 
 const RETRY_MINUTES: u64 = 5;
@@ -19,6 +22,7 @@ impl<const N: usize> SocketHandle<N> {
         path: P,
         label: &str,
         request_channel: &mut mpsc::Receiver<S>,
+        command_timeout: Duration,
     ) -> SocketResult<(Self, Vec<S>)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
@@ -73,6 +77,7 @@ impl<const N: usize> SocketHandle<N> {
                 tmp_dir,
                 socket: socket?,
                 buffer: [0; N],
+                command_timeout,
             },
             deferred_requests,
         ))
@@ -105,9 +110,10 @@ impl<const N: usize> SocketHandle<N> {
                 Err(error::ParseError::NotOK)
             }
         };
+        let timeout = self.command_timeout;
         tokio::select!(
             resp = self.parse_resp(parse) => resp,
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) =>
+            _ = tokio::time::sleep(timeout) =>
                 Ok(Err(error::ClientError::Timeout)),
         )
     }
@@ -125,7 +131,12 @@ impl<const N: usize> SocketHandle<N> {
         if n != req.len() {
             return Ok(Err(error::ClientError::DidNotWriteAllBytes(n, req.len())));
         }
-        self.parse_resp(parse).await
+        let timeout = self.command_timeout;
+        tokio::select!(
+            resp = self.parse_resp(parse) => resp,
+            _ = tokio::time::sleep(timeout) =>
+                Ok(Err(error::ClientError::Timeout)),
+        )
     }
 
     async fn parse_resp<'a, T, E, F>(&'a mut self, parse: F) -> SocketResult<Result<T>>

--- a/src/sta/event_socket.rs
+++ b/src/sta/event_socket.rs
@@ -19,12 +19,18 @@ impl EventSocket {
     pub(crate) async fn new<P>(
         socket: P,
         request_receiver: &mut mpsc::Receiver<Request>,
+        command_timeout: std::time::Duration,
     ) -> SocketResult<(Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
     {
-        let (socket_handle, deferred_requests) =
-            SocketHandle::open(socket, "wpa_ctrl_async.sock", request_receiver).await?;
+        let (socket_handle, deferred_requests) = SocketHandle::open(
+            socket,
+            "wpa_ctrl_async.sock",
+            request_receiver,
+            command_timeout,
+        )
+        .await?;
         info!("wpa_ctrl attempting attach");
         socket_handle.socket.send(b"ATTACH").await?;
         Ok((deferred_requests, Self { socket_handle }))

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -31,6 +31,8 @@ pub struct WifiStation {
     self_sender: mpsc::Sender<Request>,
     /// Timeout duration in case no valid select response is received
     select_timeout: Duration,
+    /// How long to wait for a reply to a control command/request
+    command_timeout: Duration,
 }
 
 impl WifiStation {
@@ -40,12 +42,17 @@ impl WifiStation {
             &self.socket_path,
             "mapper_wpa_ctrl_sync.sock",
             &mut self.request_receiver,
+            self.command_timeout,
         )
         .await?;
         // We start up a separate socket for receiving the "unexpected" events that
         // gets forwarded to us via the unsolicited_receiver
-        let (next_deferred_requests, unsolicited) =
-            EventSocket::new(&self.socket_path, &mut self.request_receiver).await?;
+        let (next_deferred_requests, unsolicited) = EventSocket::new(
+            &self.socket_path,
+            &mut self.request_receiver,
+            self.command_timeout,
+        )
+        .await?;
         deferred_requests.extend(next_deferred_requests);
         for request in deferred_requests {
             self.self_sender

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+/// Default time to wait for a reply to a control command/request before giving
+/// up. Chosen to comfortably cover slower wpa_supplicant operations while still
+/// unblocking the single-task runtime if a reply never arrives.
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// A convenient default type for setting up the WiFi Station process.
 pub type WifiSetup = WifiSetupGeneric<32, 32>;
 
@@ -30,6 +35,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 broadcast_sender,
                 self_sender,
                 select_timeout: Duration::from_secs(10),
+                command_timeout: DEFAULT_COMMAND_TIMEOUT,
             },
             request_client,
             broadcast_receiver,
@@ -42,6 +48,12 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
 
     pub fn set_select_timeout(&mut self, timeout: Duration) {
         self.wifi.select_timeout = timeout;
+    }
+
+    /// Set how long to wait for a reply to a control command/request before
+    /// giving up with [`ClientError::Timeout`](crate::error::ClientError::Timeout).
+    pub fn set_command_timeout(&mut self, timeout: Duration) {
+        self.wifi.command_timeout = timeout;
     }
 
     pub fn get_broadcast_receiver(&self) -> BroadcastReceiver {


### PR DESCRIPTION
- Give request()/parse_resp the same timeout command() had. Because each runtime is a single task, a reply-less STATUS/GET_CONFIG/SCAN_RESULTS/ LIST_NETWORKS/ADD_NETWORK previously froze the entire runtime, including Shutdown handling.
- Make the timeout configurable via SocketHandle::open and a new set_command_timeout() on both WifiSetupGeneric structs (default 3s; command() was a hardcoded 1s and request() had none).
- Bound the hostapd ATTACH / LOG_LEVEL DEBUG retry loops to ~60s instead of spinning forever, returning the new SocketError::AttachFailed on exhaustion.
- Remove a stale #[allow(unused)] on WifiAp::broadcast_sender.