### PR TITLE
typed, resilient status types

### DIFF
--- a/src/ap/types.rs
+++ b/src/ap/types.rs
@@ -1,40 +1,46 @@
 use super::config::ConfigError;
 use serde::{Deserialize, Serialize};
 
-/// Status of the WiFi Station
+/// Status of the WiFi Access Point
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Status {
     pub state: String,
     pub phy: String,
     pub freq: u32,
-    pub num_sta_non_erp: u64,
-    pub num_sta_no_short_slot_time: u64,
-    pub num_sta_no_short_preamble: u64,
-    pub olbc: u64,
-    pub num_sta_ht_no_gf: u64,
-    pub num_sta_no_ht: u64,
-    pub num_sta_ht_20_mhz: u64,
-    pub num_sta_ht40_intolerant: u64,
-    pub olbc_ht: u64,
-    pub ht_op_mode: String,
-    pub cac_time_seconds: u64,
+    // The fields below vary by driver, security mode, and hostapd version, so
+    // each is optional: a missing key leaves it `None` rather than failing the
+    // whole parse.
+    pub num_sta_non_erp: Option<u64>,
+    pub num_sta_no_short_slot_time: Option<u64>,
+    pub num_sta_no_short_preamble: Option<u64>,
+    pub olbc: Option<u64>,
+    pub num_sta_ht_no_gf: Option<u64>,
+    pub num_sta_no_ht: Option<u64>,
+    pub num_sta_ht_20_mhz: Option<u64>,
+    pub num_sta_ht40_intolerant: Option<u64>,
+    pub olbc_ht: Option<u64>,
+    pub ht_op_mode: Option<String>,
+    pub cac_time_seconds: Option<u64>,
     pub cac_time_left_seconds: Option<u64>,
-    pub channel: u64,
-    pub secondary_channel: u64,
-    pub ieee80211n: u64,
-    pub ieee80211ac: u64,
-    pub ieee80211ax: u64,
-    pub beacon_int: u64,
-    pub dtim_period: u64,
-    // missing if not not ieee80211n
+    pub channel: Option<u64>,
+    pub secondary_channel: Option<u64>,
+    pub ieee80211n: Option<u64>,
+    pub ieee80211ac: Option<u64>,
+    pub ieee80211ax: Option<u64>,
+    pub beacon_int: Option<u64>,
+    pub dtim_period: Option<u64>,
     pub ht_caps_info: Option<String>,
     pub ht_mcs_bitmask: Option<String>,
     #[serde(default)] // missing if there are no rates
     pub supported_rates: String,
-    pub max_txpower: u64,
+    pub max_txpower: Option<u64>,
+    #[serde(default)]
     pub bss: Vec<String>,
+    #[serde(default)]
     pub bssid: Vec<String>,
+    #[serde(default)]
     pub ssid: Vec<String>,
+    #[serde(default)]
     pub num_sta: Vec<u32>,
 }
 

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -265,7 +265,7 @@ impl WifiStation {
                                 Err(e) => {
                                     let _ = response_sender.send(Err(e));
                                 }
-                                Ok(status) if status.get("id") == Some(&id.to_string()) => {
+                                Ok(status) if status.id == Some(id) => {
                                     let _ =
                                         response_sender.send(Ok(SelectResult::AlreadyConnected));
                                 }

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -117,11 +117,50 @@ impl NetworkResult {
     }
 }
 
-/// A HashMap of what is returned when running `wpa_cli status`.
-pub type Status = HashMap<String, String>;
+/// Parsed output of `wpa_cli status`.
+///
+/// The commonly-present fields are typed for convenience; everything the
+/// supplicant reports is also available untouched via [`Status::raw`] /
+/// [`Status::get`], so newer or driver-specific keys are never lost. Missing
+/// keys simply leave the corresponding field as `None` rather than failing the
+/// whole parse.
+#[derive(Serialize, Debug, Clone, Default)]
+pub struct Status {
+    pub wpa_state: Option<String>,
+    pub ssid: Option<String>,
+    pub bssid: Option<String>,
+    pub id: Option<usize>,
+    pub freq: Option<u32>,
+    pub address: Option<String>,
+    pub ip_address: Option<String>,
+    pub key_mgmt: Option<String>,
+    pub mode: Option<String>,
+    /// Every key/value pair from the response, including those surfaced as
+    /// typed fields above.
+    pub raw: HashMap<String, String>,
+}
+
+impl Status {
+    /// Look up a raw status field the typed accessors don't cover.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.raw.get(key).map(String::as_str)
+    }
+}
 
 pub(crate) fn parse_status(response: &str) -> ParseResult<Status> {
-    Ok(config::from_str(response)?)
+    let raw: HashMap<String, String> = config::from_str(response)?;
+    Ok(Status {
+        wpa_state: raw.get("wpa_state").cloned(),
+        ssid: raw.get("ssid").cloned(),
+        bssid: raw.get("bssid").cloned(),
+        id: raw.get("id").and_then(|v| v.parse().ok()),
+        freq: raw.get("freq").and_then(|v| v.parse().ok()),
+        address: raw.get("address").cloned(),
+        ip_address: raw.get("ip_address").cloned(),
+        key_mgmt: raw.get("key_mgmt").cloned(),
+        mode: raw.get("mode").cloned(),
+        raw,
+    })
 }
 
 #[derive(Debug)]
@@ -144,5 +183,42 @@ impl Display for KeyMgmt {
             KeyMgmt::IEEE8021X => "IEEE8021X".to_string(),
         };
         write!(f, "{}", str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_status_types_known_fields_and_keeps_raw() {
+        let resp = "\
+bssid=cc:7b:5c:1a:d2:21
+freq=2412
+ssid=my-network
+id=3
+mode=station
+wpa_state=COMPLETED
+address=aa:bb:cc:dd:ee:ff
+ip_address=192.168.1.42
+some_future_key=42";
+        let status = parse_status(resp).unwrap();
+        assert_eq!(status.wpa_state.as_deref(), Some("COMPLETED"));
+        assert_eq!(status.ssid.as_deref(), Some("my-network"));
+        assert_eq!(status.id, Some(3));
+        assert_eq!(status.freq, Some(2412));
+        assert_eq!(status.ip_address.as_deref(), Some("192.168.1.42"));
+        // key_mgmt absent from the response -> None, not a parse failure
+        assert_eq!(status.key_mgmt, None);
+        // unknown keys are preserved via the raw escape hatch
+        assert_eq!(status.get("some_future_key"), Some("42"));
+    }
+
+    #[test]
+    fn parse_status_tolerates_sparse_response() {
+        let status = parse_status("wpa_state=SCANNING").unwrap();
+        assert_eq!(status.wpa_state.as_deref(), Some("SCANNING"));
+        assert_eq!(status.ssid, None);
+        assert_eq!(status.id, None);
     }
 }


### PR DESCRIPTION
- sta::Status is now a typed struct (common fields typed, everything else via raw/get) instead of a bare HashMap; unknown keys are preserved and missing ones no longer need string lookups.
- ap::Status: driver/version-specific fields are now Option and the BSS vectors default to empty, so a missing key no longer fails the whole parse. Also fixes its doc comment, which described the station.
- Use the typed id in the SelectNetwork already-connected check.

Breaking: sta::Status changes from a HashMap alias to a struct, and several ap::Status fields become Option.