### PR TITLE
Type PSK and BSSID at the API boundary instead of sniffing strings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,9 +51,9 @@ pub enum ClientError {
     /// A select request is already pending; wait for it to resolve before selecting again
     #[error("Select already pending")]
     PendingSelect,
-    /// A PSK passphrase contained characters that cannot be safely encoded for
-    /// wpa_supplicant (a double-quote, a control character, or a non-ASCII byte)
-    #[error("PSK contains characters that cannot be encoded")]
+    /// A PSK passphrase was not 8-63 printable-ASCII characters, or contained
+    /// a double-quote, which cannot be safely encoded for wpa_supplicant
+    #[error("PSK is not a valid WPA passphrase")]
     InvalidPsk,
     /// A BSSID was not a well-formed `xx:xx:xx:xx:xx:xx` MAC address
     #[error("BSSID is not a valid MAC address")]

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -60,8 +60,8 @@ impl ShutdownSignal for Request {
 #[derive(Debug)]
 pub(crate) enum SetNetwork {
     Ssid(String),
-    Bssid(String),
-    Psk(String),
+    Bssid(Bssid),
+    Psk(Psk),
     KeyMgmt(KeyMgmt),
 }
 
@@ -106,7 +106,7 @@ impl RequestClient {
         request.await?
     }
 
-    pub async fn set_network_psk(&self, network_id: usize, psk: String) -> Result {
+    pub async fn set_network_psk(&self, network_id: usize, psk: Psk) -> Result {
         let (response, request) = oneshot::channel();
         self.sender
             .send(Request::SetNetwork(
@@ -130,7 +130,7 @@ impl RequestClient {
         request.await?
     }
 
-    pub async fn set_network_bssid(&self, network_id: usize, bssid: String) -> Result {
+    pub async fn set_network_bssid(&self, network_id: usize, bssid: Bssid) -> Result {
         let (response, request) = oneshot::channel();
         self.sender
             .send(Request::SetNetwork(

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -220,27 +220,21 @@ impl WifiStation {
                 let _ = response_channel.send(network_id);
             }
             Request::SetNetwork(id, param, response) => {
-                let field = match param {
-                    SetNetwork::Ssid(ssid) => Ok(format!("ssid {}", conf_escape(&ssid))),
-                    SetNetwork::Bssid(bssid) => bssid_command(&bssid),
-                    SetNetwork::Psk(psk) => psk_command(&psk).map(|psk| format!("psk {psk}")),
-                    SetNetwork::KeyMgmt(mgmt) => Ok(format!("key_mgmt {mgmt}")),
+                // Psk and Bssid are validated at construction, so every
+                // variant formats infallibly; Psk's Debug impl redacts the
+                // key wherever the request is logged.
+                let field = match &param {
+                    SetNetwork::Ssid(ssid) => format!("ssid {}", conf_escape(ssid)),
+                    SetNetwork::Bssid(bssid) => format!("bssid {bssid}"),
+                    SetNetwork::Psk(psk) => format!("psk {}", psk.to_field()),
+                    SetNetwork::KeyMgmt(mgmt) => format!("key_mgmt {mgmt}"),
                 };
-                match field {
-                    Ok(field) => {
-                        let cmd = format!("SET_NETWORK {id} {field}");
-                        // Never log the PSK; the rest of the SET_NETWORK command is safe.
-                        if field.starts_with("psk ") {
-                            debug!("wpa_ctrl SET_NETWORK {id} psk <redacted>");
-                        } else {
-                            debug!("wpa_ctrl {cmd:?}");
-                        }
-                        let _ = response.send(socket_handle.command(cmd.as_bytes()).await?);
-                    }
-                    Err(e) => {
-                        let _ = response.send(Err(e));
-                    }
+                let cmd = format!("SET_NETWORK {id} {field}");
+                match &param {
+                    SetNetwork::Psk(_) => debug!("wpa_ctrl SET_NETWORK {id} psk <redacted>"),
+                    _ => debug!("wpa_ctrl {cmd:?}"),
                 }
+                let _ = response.send(socket_handle.command(cmd.as_bytes()).await?);
             }
             Request::SaveConfig(response) => {
                 debug!("wpa_ctrl config saved");
@@ -311,53 +305,6 @@ fn conf_escape(raw: &str) -> String {
     }
 }
 
-/// Encode a PSK for `SET_NETWORK ... psk`.
-///
-/// A 64-character hex string is a precomputed PSK, which wpa_supplicant expects
-/// raw and unquoted. Anything else is a passphrase and must be quoted: unlike an
-/// SSID, a PSK passphrase cannot be hex-encoded, because wpa_supplicant reads an
-/// unquoted value as a raw key and would misinterpret the hex.
-///
-/// A WPA passphrase is 8-63 printable-ASCII characters (spaces included), all
-/// safe inside quotes. To keep the quoted form injection-safe we reject anything
-/// that could break out of it or that has no valid representation: a literal
-/// double-quote, control characters, or non-ASCII bytes all yield
-/// [`ClientError::InvalidPsk`] rather than a malformed command.
-fn psk_command(psk: &str) -> Result<String> {
-    if psk.len() == 64 && psk.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return Ok(psk.to_string());
-    }
-    if psk
-        .bytes()
-        .any(|b| !(0x20..=0x7e).contains(&b) || b == b'"')
-    {
-        return Err(ClientError::InvalidPsk);
-    }
-    Ok(format!("\"{psk}\""))
-}
-
-/// Build a `bssid` field for `SET_NETWORK ... bssid`.
-///
-/// wpa_supplicant expects the BSSID as a raw, unquoted MAC address (quoting it
-/// makes the parse fail). Because the value is unquoted, it must be validated as
-/// a canonical `xx:xx:xx:xx:xx:xx` MAC so it can't inject extra command tokens;
-/// anything else yields [`ClientError::InvalidBssid`].
-fn bssid_command(bssid: &str) -> Result<String> {
-    let well_formed = bssid.len() == 17
-        && bssid.bytes().enumerate().all(|(i, b)| {
-            if (i + 1) % 3 == 0 {
-                b == b':'
-            } else {
-                b.is_ascii_hexdigit()
-            }
-        });
-    if well_formed {
-        Ok(format!("bssid {bssid}"))
-    } else {
-        Err(ClientError::InvalidBssid)
-    }
-}
-
 struct SelectRequest {
     response: oneshot::Sender<Result<SelectResult>>,
     timeout: tokio::task::JoinHandle<()>,
@@ -390,7 +337,10 @@ mod tests {
 
     #[test]
     fn psk_passphrase_is_quoted() {
-        assert_eq!(psk_command("password123").unwrap(), "\"password123\"");
+        assert_eq!(
+            Psk::passphrase("password123").unwrap().to_field(),
+            "\"password123\""
+        );
     }
 
     #[test]
@@ -398,16 +348,30 @@ mod tests {
         // A passphrase may contain spaces; it must stay a quoted string, since
         // an unquoted/hex value would be read as a raw pre-shared key.
         assert_eq!(
-            psk_command("correct horse battery").unwrap(),
+            Psk::passphrase("correct horse battery").unwrap().to_field(),
             "\"correct horse battery\""
         );
     }
 
     #[test]
-    fn precomputed_psk_is_raw() {
+    fn raw_psk_is_bare_hex() {
         let hex_psk = "8dbbe42cb44f21088fbb9cfbf24dc9b39787d6026d436b01b3ac7d34afb4416d";
-        assert_eq!(hex_psk.len(), 64);
-        assert_eq!(psk_command(hex_psk).unwrap(), hex_psk);
+        let mut key = [0u8; 32];
+        hex::decode_to_slice(hex_psk, &mut key).unwrap();
+        assert_eq!(Psk::raw(key).to_field(), hex_psk);
+    }
+
+    #[test]
+    fn psk_from_str_uses_conf_semantics() {
+        // Exactly 64 hex digits parses as a raw key, anything else as a
+        // passphrase; unambiguous since a passphrase is at most 63 chars.
+        let hex_psk = "8dbbe42cb44f21088fbb9cfbf24dc9b39787d6026d436b01b3ac7d34afb4416d";
+        assert_eq!(hex_psk.parse::<Psk>().unwrap().to_field(), hex_psk);
+        // 63 hex digits is a passphrase
+        assert_eq!(
+            hex_psk[..63].parse::<Psk>().unwrap().to_field(),
+            format!("\"{}\"", &hex_psk[..63])
+        );
     }
 
     #[test]
@@ -415,7 +379,7 @@ mod tests {
         // A literal quote could break out of the quoted value, so it is rejected
         // rather than emitted into the SET_NETWORK command.
         assert!(matches!(
-            psk_command("pass\"; extra"),
+            Psk::passphrase("pass\"; extra"),
             Err(ClientError::InvalidPsk)
         ));
     }
@@ -423,24 +387,59 @@ mod tests {
     #[test]
     fn psk_with_control_char_is_rejected() {
         assert!(matches!(
-            psk_command("pass\nword"),
+            Psk::passphrase("pass\nword"),
             Err(ClientError::InvalidPsk)
         ));
     }
 
     #[test]
-    fn bssid_is_sent_raw_and_unquoted() {
-        assert_eq!(
-            bssid_command("cc:7b:5c:1a:d2:21").unwrap(),
-            "bssid cc:7b:5c:1a:d2:21"
-        );
+    fn psk_outside_wpa_length_is_rejected() {
+        assert!(matches!(
+            Psk::passphrase("short"),
+            Err(ClientError::InvalidPsk)
+        ));
+        assert!(matches!(
+            Psk::passphrase("x".repeat(64)),
+            Err(ClientError::InvalidPsk)
+        ));
+    }
+
+    #[test]
+    fn psk_debug_is_redacted() {
+        let psk = Psk::passphrase("password123").unwrap();
+        assert_eq!(format!("{psk:?}"), "Psk(<redacted>)");
+        // The whole request is debug-logged by handle_request; the key must
+        // not appear through that path either.
+        let request = SetNetwork::Psk(psk);
+        assert!(!format!("{request:?}").contains("password123"));
+    }
+
+    #[test]
+    fn bssid_roundtrips_raw_and_unquoted() {
+        let bssid: Bssid = "cc:7b:5c:1a:d2:21".parse().unwrap();
+        assert_eq!(bssid.to_string(), "cc:7b:5c:1a:d2:21");
+        assert_eq!(Bssid::from([0xcc, 0x7b, 0x5c, 0x1a, 0xd2, 0x21]), bssid);
+    }
+
+    #[test]
+    fn bssid_is_canonicalized() {
+        // Mixed case parses but is always emitted lowercase
+        let bssid: Bssid = "CC:7B:5C:1A:D2:21".parse().unwrap();
+        assert_eq!(bssid.to_string(), "cc:7b:5c:1a:d2:21");
     }
 
     #[test]
     fn malformed_bssid_is_rejected() {
-        for bad in ["cc:7b:5c:1a:d2", "cc:7b:5c:1a:d2:21 x", "not-a-mac", ""] {
+        for bad in [
+            "cc:7b:5c:1a:d2",
+            "cc:7b:5c:1a:d2:21:33",
+            "cc:7b:5c:1a:d2:21 x",
+            "cc:7b:5c:1a:d2:+1",
+            "not-a-mac",
+            "",
+        ] {
             assert!(
-                matches!(bssid_command(bad), Err(ClientError::InvalidBssid)),
+                matches!(bad.parse::<Bssid>(), Err(ClientError::InvalidBssid)),
                 "expected {bad:?} to be rejected"
             );
         }

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -1,5 +1,6 @@
 use super::{config, config::unprintf, warn, Result, SocketHandle};
 use super::{ParseResult, SocketResult};
+use crate::error::ClientError;
 
 use serde::Serialize;
 use std::collections::HashMap;
@@ -144,5 +145,125 @@ impl Display for KeyMgmt {
             KeyMgmt::IEEE8021X => "IEEE8021X".to_string(),
         };
         write!(f, "{}", str)
+    }
+}
+
+/// A WPA pre-shared key, validated at construction.
+///
+/// wpa_supplicant takes the `psk` field in two distinct forms and encodes them
+/// differently on the control socket: a passphrase is sent as a quoted string,
+/// while a precomputed 256-bit key is sent as raw, unquoted hex. An unquoted
+/// value is always read as a raw key, so a passphrase can never fall back to
+/// hex encoding the way an SSID can. The two constructors let the caller say
+/// which form it means instead of the library guessing from the string's shape.
+///
+/// Use [`Psk::passphrase`] or [`Psk::raw`] when the kind is known; parse with
+/// `str::parse` to get `wpa_supplicant.conf` semantics (exactly 64 hex digits
+/// is a raw key, anything else a passphrase — unambiguous because a passphrase
+/// is at most 63 characters).
+#[derive(Clone, PartialEq, Eq)]
+pub struct Psk(PskInner);
+
+#[derive(Clone, PartialEq, Eq)]
+enum PskInner {
+    Passphrase(String),
+    Raw([u8; 32]),
+}
+
+impl Psk {
+    /// A WPA passphrase: 8-63 printable-ASCII characters (spaces included).
+    ///
+    /// A literal double-quote is rejected even though WPA formally allows it:
+    /// the control socket has no escape for one inside a quoted value, so it
+    /// has no safe representation. Anything else outside printable ASCII has
+    /// no valid representation either. Both yield [`ClientError::InvalidPsk`].
+    pub fn passphrase(passphrase: impl Into<String>) -> Result<Self> {
+        let passphrase = passphrase.into();
+        let quotable = passphrase
+            .bytes()
+            .all(|b| (0x20..=0x7e).contains(&b) && b != b'"');
+        if !quotable || !(8..=63).contains(&passphrase.len()) {
+            return Err(ClientError::InvalidPsk);
+        }
+        Ok(Psk(PskInner::Passphrase(passphrase)))
+    }
+
+    /// A precomputed 256-bit key, as produced by `wpa_passphrase` or
+    /// equivalent PBKDF2 derivation.
+    pub fn raw(key: [u8; 32]) -> Self {
+        Psk(PskInner::Raw(key))
+    }
+
+    /// Encode the value of `SET_NETWORK <id> psk <value>`: a passphrase is
+    /// quoted, a raw key is bare lowercase hex.
+    pub(crate) fn to_field(&self) -> String {
+        match &self.0 {
+            PskInner::Passphrase(passphrase) => format!("\"{passphrase}\""),
+            PskInner::Raw(key) => hex::encode(key),
+        }
+    }
+}
+
+impl FromStr for Psk {
+    type Err = ClientError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit()) {
+            let mut key = [0u8; 32];
+            hex::decode_to_slice(s, &mut key).expect("64 hex digits");
+            return Ok(Psk::raw(key));
+        }
+        Self::passphrase(s)
+    }
+}
+
+/// Never print key material: `Request` (and `SetNetwork` inside it) is logged
+/// at debug level with `{:?}`.
+impl std::fmt::Debug for Psk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Psk(<redacted>)")
+    }
+}
+
+/// A BSSID (access-point MAC address).
+///
+/// wpa_supplicant expects the `bssid` field raw and unquoted (a quoted MAC
+/// fails to parse). Parsing up front and re-emitting the canonical
+/// `xx:xx:xx:xx:xx:xx` form via [`Display`] means caller input is never echoed
+/// into an unquoted command position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bssid([u8; 6]);
+
+impl From<[u8; 6]> for Bssid {
+    fn from(mac: [u8; 6]) -> Self {
+        Bssid(mac)
+    }
+}
+
+impl FromStr for Bssid {
+    type Err = ClientError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let mut mac = [0u8; 6];
+        let mut octets = s.split(':');
+        for byte in mac.iter_mut() {
+            let octet = octets.next().ok_or(ClientError::InvalidBssid)?;
+            // from_str_radix alone would admit signs and whitespace
+            if octet.len() != 2 || !octet.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return Err(ClientError::InvalidBssid);
+            }
+            *byte = u8::from_str_radix(octet, 16).map_err(|_| ClientError::InvalidBssid)?;
+        }
+        if octets.next().is_some() {
+            return Err(ClientError::InvalidBssid);
+        }
+        Ok(Bssid(mac))
+    }
+}
+
+impl Display for Bssid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let [a, b, c, d, e, g] = self.0;
+        write!(f, "{a:02x}:{b:02x}:{c:02x}:{d:02x}:{e:02x}:{g:02x}")
     }
 }


### PR DESCRIPTION
Builds on #21 — targets `fix/credential-encoding`, so merging this folds it into that PR.

The encoding fixes in #21 are right (quoted passphrases, raw 64-hex, unquoted BSSID, redacted logs), but the worker loop re-derives the caller's intent with a string-shape heuristic and validation errors round-trip through the request channel. This moves both to the type system at the input boundary:

- **`Psk` enum** (`Passphrase`/`Raw([u8; 32])`): the caller states which form it means instead of the library guessing from 64-hex-ness. `Psk::passphrase()` validates 8–63 printable ASCII (length was previously unchecked — a 4-char passphrase sailed through to a bare `FAIL`); `Psk::raw()` takes the key bytes. `FromStr` keeps the wpa_supplicant.conf 64-hex convention as an explicit opt-in for callers holding config strings.
- **Redacting `Debug` on `Psk`**: #21's redaction covered the `SET_NETWORK` line but the key still leaked through `debug!("Handling request: {request:?}")` at the top of `handle_request`, since `SetNetwork::Psk(String)` derived `Debug`. The manual impl plugs that everywhere at once, including future log sites.
- **`Bssid([u8; 6])`**: parses the canonical MAC form and re-emits it lowercase via `Display`, so caller input is never echoed into an unquoted command position (also rejects `from_str_radix` quirks like `+1` octets).
- **Worker loop is infallible again**: `InvalidPsk`/`InvalidBssid` are returned synchronously from the constructors before the request is enqueued; `psk_command`/`bssid_command` and the `starts_with("psk ")` re-detection are gone.

Breaking change to `set_network_psk`/`set_network_bssid` signatures (`String` → `Psk`/`Bssid`), which seems fine pre-1.0 — callers migrating mechanically can use `.parse()?`.

Tests carried over from #21 and extended (conf-semantics boundary at 63/64 chars, length limits, Debug redaction, MAC canonicalization). `cargo test --offline`, clippy, and fmt all clean.