### PR TITLE
docs: add doctests, intra-doc links, and a crate-level quick start

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,31 @@
 //! Tokio-based runtimes for communicating with hostapd and wpa-supplicant.
 //!
+//! Use [`sta`] to run a WiFi station (network client) against `wpa_supplicant`,
+//! and [`ap`] to run an access point against `hostapd`.
+//!
 //! # Quick Start
 //!
-//! Checkout the examples [on Github](https://github.com/novalabsxyz/wifi-ctrl) for a quick start.
+//! ```no_run
+//! use wifi_ctrl::sta;
 //!
+//! #[tokio::main]
+//! async fn main() -> wifi_ctrl::Result {
+//!     let mut setup = sta::WifiSetup::new();
+//!     setup.set_socket_path("/var/run/wpa_supplicant/wlan0");
+//!     let requester = setup.get_request_client();
+//!     let mut runtime = setup.complete();
+//!     tokio::spawn(async move { runtime.run().await });
+//!
+//!     let scan = requester.get_scan().await?;
+//!     for network in scan.iter() {
+//!         println!("{} {}", network.signal, network.name);
+//!     }
+//!     requester.shutdown().await
+//! }
+//! ```
+//!
+//! See the examples [on Github](https://github.com/novalabsxyz/wifi-ctrl) for
+//! complete station and access-point programs.
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/sta/client.rs
+++ b/src/sta/client.rs
@@ -105,6 +105,7 @@ impl RequestClient {
         self.request(Request::AddNetwork).await
     }
 
+    /// Set the network's pre-shared key. See [`Psk`] for the accepted forms.
     pub async fn set_network_psk(&self, network_id: usize, psk: Psk) -> Result {
         self.request(|response| Request::SetNetwork(network_id, SetNetwork::Psk(psk), response))
             .await
@@ -115,11 +116,13 @@ impl RequestClient {
             .await
     }
 
+    /// Pin the network to a specific access point by [`Bssid`].
     pub async fn set_network_bssid(&self, network_id: usize, bssid: Bssid) -> Result {
         self.request(|response| Request::SetNetwork(network_id, SetNetwork::Bssid(bssid), response))
             .await
     }
 
+    /// Set the network's key management mode; see [`KeyMgmt`].
     pub async fn set_network_keymgmt(&self, network_id: usize, mgmt: KeyMgmt) -> Result {
         self.request(|response| {
             Request::SetNetwork(network_id, SetNetwork::KeyMgmt(mgmt), response)

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -197,9 +197,26 @@ impl Display for KeyMgmt {
 /// which form it means instead of the library guessing from the string's shape.
 ///
 /// Use [`Psk::passphrase`] or [`Psk::raw`] when the kind is known; parse with
-/// `str::parse` to get `wpa_supplicant.conf` semantics (exactly 64 hex digits
+/// [`str::parse`] to get `wpa_supplicant.conf` semantics (exactly 64 hex digits
 /// is a raw key, anything else a passphrase — unambiguous because a passphrase
 /// is at most 63 characters).
+///
+/// ```
+/// use wifi_ctrl::sta::Psk;
+///
+/// // The constructors say which form is meant.
+/// let psk = Psk::passphrase("correct horse battery")?;
+/// let _key = Psk::raw([0x42; 32]);
+///
+/// // Parsing follows wpa_supplicant.conf: anything but 64 hex digits is a passphrase,
+/// // and passphrases outside 8-63 printable-ASCII characters are rejected.
+/// let _parsed: Psk = "correct horse battery".parse()?;
+/// assert!("short".parse::<Psk>().is_err());
+///
+/// // Debug never reveals key material.
+/// assert_eq!(format!("{psk:?}"), "Psk(<redacted>)");
+/// # Ok::<(), wifi_ctrl::error::ClientError>(())
+/// ```
 // No PartialEq/Eq: nothing compares PSKs, and a derived comparison over key
 // material would not be constant-time. Add a constant-time compare (e.g.
 // `subtle::ConstantTimeEq`) if equality is ever needed.
@@ -219,6 +236,13 @@ impl Psk {
     /// the control socket has no escape for one inside a quoted value, so it
     /// has no safe representation. Anything else outside printable ASCII has
     /// no valid representation either. Both yield [`ClientError::InvalidPsk`].
+    ///
+    /// ```
+    /// # use wifi_ctrl::sta::Psk;
+    /// assert!(Psk::passphrase("password123").is_ok());
+    /// assert!(Psk::passphrase("2short").is_err());
+    /// assert!(Psk::passphrase("pass\"word123").is_err()); // no escape for a quote
+    /// ```
     pub fn passphrase(passphrase: impl Into<String>) -> Result<Self> {
         let passphrase = passphrase.into();
         let quotable = passphrase
@@ -273,6 +297,18 @@ impl std::fmt::Debug for Psk {
 /// fails to parse). Parsing up front and re-emitting the canonical
 /// `xx:xx:xx:xx:xx:xx` form via [`Display`] means caller input is never echoed
 /// into an unquoted command position.
+///
+/// ```
+/// use wifi_ctrl::sta::Bssid;
+///
+/// let bssid: Bssid = "CC:7B:5C:1A:D2:21".parse()?;
+/// // Always re-emitted in canonical lowercase form.
+/// assert_eq!(bssid.to_string(), "cc:7b:5c:1a:d2:21");
+/// assert_eq!(bssid, Bssid::from([0xcc, 0x7b, 0x5c, 0x1a, 0xd2, 0x21]));
+///
+/// assert!("cc:7b:5c:1a:d2".parse::<Bssid>().is_err());
+/// # Ok::<(), wifi_ctrl::error::ClientError>(())
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Bssid([u8; 6]);
 


### PR DESCRIPTION
Documentation follow-up to #21:

- **Crate-level quick start**: a compile-checked (`no_run`) example in the crate docs showing the station flow end to end — setup, socket path, spawning the runtime, scanning, shutdown. The crate docs also now link to the `sta` and `ap` modules.
- **Doctests on the new types**:
  - `Psk`: constructors, `.parse()` conf-semantics, and Debug redaction
  - `Psk::passphrase`: rejection of too-short and quote-containing passphrases
  - `Bssid`: mixed-case parse → canonical lowercase, `From<[u8; 6]>` equivalence, malformed rejection
- **Intra-doc links** from the `RequestClient` setters (`set_network_psk`/`set_network_bssid`/`set_network_keymgmt`) to `Psk`/`Bssid`/`KeyMgmt`, where the validation rules are documented.
- **Fix**: `html_root_url` pointed at `https://docs.rs/wpactrl/` (a different crate); now `https://docs.rs/wifi-ctrl/`.

Verified with `cargo test` (18 unit + 7 doc tests) and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all intra-doc links resolve).