### PR TITLE
Drop Eq on Psk (constant-time) and misc cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ log = { version = "0.4" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 tempfile = "3"
-tokio = { version = "1", default-features = false, features = ["net", "sync", "macros", "time"] }
+tokio = { version = "1.30", default-features = false, features = ["net", "sync", "macros", "time"] }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ futures = "0.3"
 
 [lints.rust]
 unsafe_code = "warn"
+unused_qualifications = "warn"

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -24,9 +24,6 @@ pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
     wifi: WifiAp,
     /// Client for making requests
     request_client: RequestClient,
-    #[allow(unused)]
-    /// Client for receiving alerts
-    broadcast_receiver: BroadcastReceiver,
 }
 
 impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
@@ -35,7 +32,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
         let (self_sender, request_receiver) = mpsc::channel(C);
         let request_client = RequestClient::new(self_sender.clone());
         // setup the channel for broadcasts
-        let (broadcast_sender, broadcast_receiver) = broadcast::channel(B);
+        let (broadcast_sender, _) = broadcast::channel(B);
 
         Self {
             wifi: WifiAp {
@@ -49,7 +46,6 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 attach_retry_delay: DEFAULT_ATTACH_RETRY_DELAY,
             },
             request_client,
-            broadcast_receiver,
         }
     }
 

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -31,8 +31,8 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
         // setup the channel for client requests
         let (self_sender, request_receiver) = mpsc::channel(C);
         let request_client = RequestClient::new(self_sender.clone());
-        // setup the channel for broadcasts
-        let (broadcast_sender, _) = broadcast::channel(B);
+        // setup the sender for broadcasts; receivers subscribe on demand
+        let broadcast_sender = broadcast::Sender::new(B);
 
         Self {
             wifi: WifiAp {

--- a/src/ap/types.rs
+++ b/src/ap/types.rs
@@ -90,7 +90,7 @@ impl Status {
     /// assert_eq!(status.ssid, vec![r"WiFi-SSID", r#"¯\_(ツ)_/¯"#]);
     /// assert_eq!(status.num_sta, vec![0, 1]);
     /// ```
-    pub fn from_response(response: &str) -> std::result::Result<Self, ConfigError> {
+    pub fn from_response(response: &str) -> Result<Self, ConfigError> {
         crate::config::from_str(response)
     }
 }
@@ -129,7 +129,7 @@ impl Config {
     /// assert_eq!(config.wpa, 2);
     /// assert_eq!(config.ssid, "WiFi-SSID");
     /// ```
-    pub fn from_response(response: &str) -> std::result::Result<Self, ConfigError> {
+    pub fn from_response(response: &str) -> Result<Self, ConfigError> {
         crate::config::from_str(response)
     }
 }

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -50,14 +50,14 @@ impl<const N: usize> SocketHandle<N> {
                                 info!("Failed to connect to {socket_debug}, retrying for {} more minutes", RETRY_MINUTES-(loop_count+1)/60);
                             }
                             loop_count+=1;
-                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                            tokio::time::sleep(Duration::from_secs(1)).await;
                         }
                     }
                 };
                 s
             } => resp,
             _ = async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(60*RETRY_MINUTES)).await;
+                tokio::time::sleep(Duration::from_secs(60*RETRY_MINUTES)).await;
             } => Err(error::SocketError::TimeoutOpeningSocket(socket_debug.to_string())),
             _ = async move {
                 loop {
@@ -101,20 +101,20 @@ impl<const N: usize> SocketHandle<N> {
     ) -> SocketResult<Result> {
         let n = self.socket.send(cmd).await?;
         if n != cmd.len() {
-            return Ok(Err(error::ClientError::DidNotWriteAllBytes(n, cmd.len())));
+            return Ok(Err(ClientError::DidNotWriteAllBytes(n, cmd.len())));
         }
         let parse = |data: &str| {
             if accept(data) {
                 Ok(())
             } else {
-                Err(error::ParseError::NotOK)
+                Err(ParseError::NotOK)
             }
         };
         let timeout = self.command_timeout;
         tokio::select!(
             resp = self.parse_resp(parse) => resp,
             _ = tokio::time::sleep(timeout) =>
-                Ok(Err(error::ClientError::Timeout)),
+                Ok(Err(ClientError::Timeout)),
         )
     }
 
@@ -129,13 +129,13 @@ impl<const N: usize> SocketHandle<N> {
     {
         let n = self.socket.send(req.as_bytes()).await?;
         if n != req.len() {
-            return Ok(Err(error::ClientError::DidNotWriteAllBytes(n, req.len())));
+            return Ok(Err(ClientError::DidNotWriteAllBytes(n, req.len())));
         }
         let timeout = self.command_timeout;
         tokio::select!(
             resp = self.parse_resp(parse) => resp,
             _ = tokio::time::sleep(timeout) =>
-                Ok(Err(error::ClientError::Timeout)),
+                Ok(Err(ClientError::Timeout)),
         )
     }
 

--- a/src/sta/event_socket.rs
+++ b/src/sta/event_socket.rs
@@ -19,7 +19,7 @@ impl EventSocket {
     pub(crate) async fn new<P>(
         socket: P,
         request_receiver: &mut mpsc::Receiver<Request>,
-        command_timeout: std::time::Duration,
+        command_timeout: Duration,
     ) -> SocketResult<(Vec<Request>, Self)>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -151,7 +151,7 @@ impl WifiStation {
             }
             Event::ScanFailed => {
                 while let Some(scan_request) = scan_requests.pop() {
-                    let _ = scan_request.send(Err(error::ClientError::Failed));
+                    let _ = scan_request.send(Err(ClientError::Failed));
                 }
             }
             Event::Connected => {
@@ -310,7 +310,7 @@ impl WifiStation {
     }
 }
 
-/// convert to wpa config format idealy a "quoted string"
+/// convert to wpa config format, ideally a "quoted string"
 /// in case of new-lines, quotes or emoji fall back to hex encoding the whole thing
 fn conf_escape(raw: &str) -> String {
     if raw.bytes().all(|b| b.is_ascii_graphic() && b != b'"') {

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -22,8 +22,8 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
         // setup the channel for client requests
         let (self_sender, request_receiver) = mpsc::channel(C);
         let request_client = RequestClient::new(self_sender.clone());
-        // setup the channel for broadcasts
-        let (broadcast_sender, _) = broadcast::channel(B);
+        // setup the sender for broadcasts; receivers subscribe on demand
+        let broadcast_sender = broadcast::Sender::new(B);
 
         Self {
             wifi: WifiStation {

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -15,9 +15,6 @@ pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
     wifi: WifiStation,
     /// Client for making requests
     request_client: RequestClient,
-    #[allow(unused)]
-    /// Client for receiving alerts
-    broadcast_receiver: BroadcastReceiver,
 }
 
 impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
@@ -26,7 +23,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
         let (self_sender, request_receiver) = mpsc::channel(C);
         let request_client = RequestClient::new(self_sender.clone());
         // setup the channel for broadcasts
-        let (broadcast_sender, broadcast_receiver) = broadcast::channel(B);
+        let (broadcast_sender, _) = broadcast::channel(B);
 
         Self {
             wifi: WifiStation {
@@ -38,7 +35,6 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
                 command_timeout: DEFAULT_COMMAND_TIMEOUT,
             },
             request_client,
-            broadcast_receiver,
         }
     }
 

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -200,10 +200,13 @@ impl Display for KeyMgmt {
 /// `str::parse` to get `wpa_supplicant.conf` semantics (exactly 64 hex digits
 /// is a raw key, anything else a passphrase — unambiguous because a passphrase
 /// is at most 63 characters).
-#[derive(Clone, PartialEq, Eq)]
+// No PartialEq/Eq: nothing compares PSKs, and a derived comparison over key
+// material would not be constant-time. Add a constant-time compare (e.g.
+// `subtle::ConstantTimeEq`) if equality is ever needed.
+#[derive(Clone)]
 pub struct Psk(PskInner);
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 enum PskInner {
     Passphrase(String),
     Raw([u8; 32]),


### PR DESCRIPTION
Follow-ups to the PSK/BSSID hardening in #21:

Security:
- Drop the PartialEq/Eq derive on Psk. Nothing compares PSKs, and a derived comparison over the key material would not be constant-time; add a constant-time compare (e.g. subtle::ConstantTimeEq) if equality is needed.

Cleanup:
- Fix the unused_qualifications warnings and enable the lint in Cargo.toml.
- Remove the stored-but-unused broadcast_receiver field from both WifiSetupGeneric structs; get_broadcast_receiver subscribes fresh from the sender, so the zombie receiver only held an undrained channel slot.
- Fix an "idealy" -> "ideally" typo in conf_escape.