### PR TITLE
CI docs check + crates.io/docs.rs badges

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,3 +39,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      # Build the docs the way docs.rs will, treating rustdoc warnings
+      # (broken intra-doc links, bad code fences, etc.) as errors
+      - name: Docs
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: "-D warnings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 description = "Tokio-based runtimes for communicating with hostapd and wpa-supplicant"
 license = "Apache-2.0"
 repository = "https://github.com/novalabsxyz/wifi-ctrl"
+documentation = "https://docs.rs/wifi-ctrl"
 readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
 rust-version = "1.64"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Continuous Integration](https://github.com/novalabsxyz/wifi-ctrl/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/novalabsxyz/wifi-ctrl/actions/workflows/rust.yml)
+[![crates.io](https://img.shields.io/crates/v/wifi-ctrl.svg)](https://crates.io/crates/wifi-ctrl)
+[![Documentation](https://docs.rs/wifi-ctrl/badge.svg)](https://docs.rs/wifi-ctrl)
 # wifi-ctrl
 
 Tokio-based runtimes for communicating with hostapd and wpa-supplicant.


### PR DESCRIPTION
Two small docs-hygiene changes:

- **Docs step in CI**: builds `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`, so broken intra-doc links (like the `[`Status::raw`]`-style references the recent typed-API work added) and malformed doc comments fail PR CI instead of shipping broken to docs.rs. Verified green against current `main`.
- **Badges + metadata**: crates.io version and docs.rs badges in the README, and a `documentation` field in Cargo.toml so the crates.io sidebar links straight to docs.rs.

Kept the step in the existing `build-linux` job in the same style as its neighbors rather than restructuring the workflow (the `actions-rs` actions are deprecated, but that's a separate cleanup).