### PR TITLE
fix MSRV job by stripping dev-deps instead of using cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.70.0"
+          toolchain: "1.71.0"
           default: true
           override: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,12 +60,12 @@ jobs:
           default: true
           override: true
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
-
-      # Verify the library builds on the declared rust-version. --no-dev-deps
-      # skips dev-only crates: they don't affect downstream consumers and their
-      # newer releases no longer resolve on this old toolchain.
-      - name: Check MSRV
-        run: cargo hack --no-dev-deps check
+      # Verify the library builds on the declared rust-version. Dev-only deps are
+      # stripped first: consumers never pull them, and env_logger 0.11's newer
+      # transitive deps no longer resolve on this old toolchain (which would
+      # otherwise fail lockfile generation before the check even runs).
+      - name: Check MSRV (library only)
+        run: |
+          awk '/^\[dev-dependencies\]/{skip=1} /^\[/ && !/^\[dev-dependencies\]/{skip=0} !skip' Cargo.toml > Cargo.toml.msrv
+          mv Cargo.toml.msrv Cargo.toml
+          cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ hex = "0.4"
 log = { version = "0.4" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
-tempfile = "3"
+# Capped below 3.16 for MSRV: 3.16+ resolves getrandom 0.3/0.4, which are (or
+# transitively pull, via wit-bindgen) edition-2024 crates that cargo 1.70 can't
+# even parse. <3.16 resolves getrandom 0.2, keeping the graph 1.70-buildable.
+tempfile = ">=3, <3.16"
 tokio = { version = "1.30", default-features = false, features = ["net", "sync", "macros", "time"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/novalabsxyz/wifi-ctrl"
 documentation = "https://docs.rs/wifi-ctrl"
 readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
-rust-version = "1.70"
+rust-version = "1.71"
 
 [dependencies]
 hex = "0.4"
@@ -17,8 +17,9 @@ log = { version = "0.4" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
 # Capped below 3.16 for MSRV: 3.16+ resolves getrandom 0.3/0.4, which are (or
-# transitively pull, via wit-bindgen) edition-2024 crates that cargo 1.70 can't
-# even parse. <3.16 resolves getrandom 0.2, keeping the graph 1.70-buildable.
+# transitively pull, via wit-bindgen) edition-2024 crates -- unparseable by any
+# cargo before 1.85. <3.16 resolves getrandom 0.2, keeping the graph buildable
+# on the MSRV toolchain.
 tempfile = ">=3, <3.16"
 tokio = { version = "1.30", default-features = false, features = ["net", "sync", "macros", "time"] }
 


### PR DESCRIPTION
The `cargo hack --no-dev-deps` approach still runs `cargo generate-lockfile` on the full manifest first, which fails on 1.70: env_logger 0.11's newer transitive deps no longer resolve on that toolchain. Strip [dev-dependencies] from the manifest before `cargo check` instead -- consumers never pull dev-deps, so they don't belong in an MSRV check anyway.