### PR TITLE
Upgrade crate to Rust 2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,16 +56,9 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.71.0"
+          toolchain: "1.85.0"
           default: true
           override: true
 
-      # Verify the library builds on the declared rust-version. Dev-only deps are
-      # stripped first: consumers never pull them, and env_logger 0.11's newer
-      # transitive deps no longer resolve on this old toolchain (which would
-      # otherwise fail lockfile generation before the check even runs).
-      - name: Check MSRV (library only)
-        run: |
-          awk '/^\[dev-dependencies\]/{skip=1} /^\[/ && !/^\[dev-dependencies\]/{skip=0} !skip' Cargo.toml > Cargo.toml.msrv
-          mv Cargo.toml.msrv Cargo.toml
-          cargo check
+      - name: Check MSRV
+        run: cargo check --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,7 @@ hex = "0.4"
 log = { version = "0.4" }
 serde =  {version = "1", features = ["derive"] }
 thiserror = "1"
-# Capped below 3.16 for MSRV: 3.16+ resolves getrandom 0.3/0.4, which are (or
-# transitively pull, via wit-bindgen) edition-2024 crates -- unparseable by any
-# cargo before 1.85. <3.16 resolves getrandom 0.2, keeping the graph buildable
-# on the MSRV toolchain.
-tempfile = ">=3, <3.16"
+tempfile = "3"
 tokio = { version = "1.30", default-features = false, features = ["net", "sync", "macros", "time"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wifi-ctrl"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 description = "Tokio-based runtimes for communicating with hostapd and wpa-supplicant"
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/novalabsxyz/wifi-ctrl"
 documentation = "https://docs.rs/wifi-ctrl"
 readme = "README.md"
 keywords = ["hostapd", "wpa-supplicant", "wpa_supplicant", "wpa-cli", "wifi"]
-rust-version = "1.71"
+rust-version = "1.85"
 
 [dependencies]
 hex = "0.4"

--- a/examples/wifi-ap.rs
+++ b/examples/wifi-ap.rs
@@ -3,7 +3,7 @@ use env_logger::Env;
 use log::{error, info};
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use tokio::io;
-use wifi_ctrl::{ap, Result};
+use wifi_ctrl::{Result, ap};
 
 #[tokio::main]
 async fn main() -> Result {

--- a/examples/wifi-sta.rs
+++ b/examples/wifi-sta.rs
@@ -3,7 +3,7 @@ use env_logger::Env;
 use log::{error, info};
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use tokio::io;
-use wifi_ctrl::{sta, Result};
+use wifi_ctrl::{Result, sta};
 
 #[tokio::main]
 async fn main() -> Result {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use serde::de::value::MapDeserializer;
 use serde::de::{self, Error, IntoDeserializer, Visitor};
-use serde::{forward_to_deserialize_any, Deserialize};
+use serde::{Deserialize, forward_to_deserialize_any};
 
 type Result<T> = std::result::Result<T, ConfigError>;
 

--- a/src/socket_handle.rs
+++ b/src/socket_handle.rs
@@ -67,7 +67,7 @@ impl<const N: usize> SocketHandle<N> {
                         } else {
                             deferred_requests_handle.push(request);
                         }
-                    }
+                    };
                 }
             } => Err(error::SocketError::StartupAborted),
         );

--- a/src/sta/mod.rs
+++ b/src/sta/mod.rs
@@ -126,7 +126,7 @@ impl WifiStation {
                 EventOrRequest::SelectTimeout => {
                     if let Some(sender) = select_request.take() {
                         sender.send(Err(ClientError::Timeout));
-                    }
+                    };
                 }
             }
         }

--- a/src/sta/types.rs
+++ b/src/sta/types.rs
@@ -1,5 +1,5 @@
-use super::{config, config::unprintf, warn, Result, SocketHandle};
 use super::{ParseResult, SocketResult};
+use super::{Result, SocketHandle, config, config::unprintf, warn};
 use crate::error::ClientError;
 
 use serde::Serialize;


### PR DESCRIPTION
## Summary
- switch the crate to Rust edition 2024
- raise the crate MSRV to Rust 1.85, the first stable release with edition 2024
- make two 2024 tail-temporary drop-order sites explicit and apply rustfmt import ordering

## Verification
- cargo fmt --check
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- cargo +1.85.0 check --all-targets --all-features
- cargo +1.85.0 test --all-targets --all-features