### PR TITLE
Replace channel-size const generics with with_capacities constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are preserved. Driver/version-specific `ap::Status` fields are now `Option`
   and the BSS vectors default to empty, so a missing key no longer fails the
   whole parse.
+- **Breaking:** `WifiSetupGeneric<C, B>` is gone; `WifiSetup` is now a plain
+  struct. Channel capacities default to 32; use `WifiSetup::with_capacities()`
+  to construct with explicit request and broadcast channel sizes.
 - **Breaking:** renamed `ConfigError::MissingDelimterEqual` to
   `MissingDelimiterEqual`.
 - **Breaking:** removed the event channel; events are now handled directly by

--- a/src/ap/setup.rs
+++ b/src/ap/setup.rs
@@ -14,25 +14,30 @@ const DEFAULT_ATTACH_RETRIES: usize = 240;
 /// Default delay between attach handshake attempts.
 const DEFAULT_ATTACH_RETRY_DELAY: Duration = Duration::from_millis(250);
 
-/// A convenient default type for setting up the WiFiAp process.
-pub type WifiSetup = WifiSetupGeneric<32, 32>;
+/// Default capacity of the request and broadcast channels.
+const DEFAULT_CHANNEL_SIZE: usize = 32;
 
-/// The generic WifiSetup struct which has generic constant parameters for adjusting queue size.
-/// WiFiSetup type is provided for convenience.
-pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
+/// Setup struct for the WiFiAp process.
+pub struct WifiSetup {
     /// Struct for handling runtime process
     wifi: WifiAp,
     /// Client for making requests
     request_client: RequestClient,
 }
 
-impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
+impl WifiSetup {
     pub fn new() -> Self {
+        Self::with_capacities(DEFAULT_CHANNEL_SIZE, DEFAULT_CHANNEL_SIZE)
+    }
+
+    /// Like [`Self::new`] but with explicit request and broadcast channel
+    /// capacities (both default to 32).
+    pub fn with_capacities(request_channel_size: usize, broadcast_channel_size: usize) -> Self {
         // setup the channel for client requests
-        let (self_sender, request_receiver) = mpsc::channel(C);
+        let (self_sender, request_receiver) = mpsc::channel(request_channel_size);
         let request_client = RequestClient::new(self_sender.clone());
         // setup the sender for broadcasts; receivers subscribe on demand
-        let broadcast_sender = broadcast::Sender::new(B);
+        let broadcast_sender = broadcast::Sender::new(broadcast_channel_size);
 
         Self {
             wifi: WifiAp {
@@ -89,7 +94,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     }
 }
 
-impl Default for WifiSetupGeneric {
+impl Default for WifiSetup {
     fn default() -> Self {
         Self::new()
     }

--- a/src/sta/setup.rs
+++ b/src/sta/setup.rs
@@ -5,25 +5,30 @@ use super::*;
 /// unblocking the single-task runtime if a reply never arrives.
 const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// A convenient default type for setting up the WiFi Station process.
-pub type WifiSetup = WifiSetupGeneric<32, 32>;
+/// Default capacity of the request and broadcast channels.
+const DEFAULT_CHANNEL_SIZE: usize = 32;
 
-/// The generic WifiSetup struct which has generic constant parameters for adjusting queue size.
-/// WiFiSetup type is provided for convenience.
-pub struct WifiSetupGeneric<const C: usize = 32, const B: usize = 32> {
+/// Setup struct for the WiFi Station process.
+pub struct WifiSetup {
     /// Struct for handling runtime process
     wifi: WifiStation,
     /// Client for making requests
     request_client: RequestClient,
 }
 
-impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
+impl WifiSetup {
     pub fn new() -> Self {
+        Self::with_capacities(DEFAULT_CHANNEL_SIZE, DEFAULT_CHANNEL_SIZE)
+    }
+
+    /// Like [`Self::new`] but with explicit request and broadcast channel
+    /// capacities (both default to 32).
+    pub fn with_capacities(request_channel_size: usize, broadcast_channel_size: usize) -> Self {
         // setup the channel for client requests
-        let (self_sender, request_receiver) = mpsc::channel(C);
+        let (self_sender, request_receiver) = mpsc::channel(request_channel_size);
         let request_client = RequestClient::new(self_sender.clone());
         // setup the sender for broadcasts; receivers subscribe on demand
-        let broadcast_sender = broadcast::Sender::new(B);
+        let broadcast_sender = broadcast::Sender::new(broadcast_channel_size);
 
         Self {
             wifi: WifiStation {
@@ -64,7 +69,7 @@ impl<const C: usize, const B: usize> WifiSetupGeneric<C, B> {
     }
 }
 
-impl Default for WifiSetupGeneric {
+impl Default for WifiSetup {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
Style cleanup ahead of 0.3.0: the `WifiSetupGeneric<C, B>` const generics carried request/broadcast channel capacities through every use of the type for a value that only matters at construction.

- `WifiSetupGeneric` and the `WifiSetup` alias are gone; `WifiSetup` is now a plain struct in both `sta` and `ap`.
- `new()` uses the default capacity of 32 for both channels; `with_capacities(request_channel_size, broadcast_channel_size)` sets them explicitly.
- Because capacities are fixed at construction, there is no resize-after-endpoints-handed-out hazard, so no new error variants are needed.
- CHANGELOG updated under the unreleased 0.3.0 breaking changes.

Tests (18 unit + 7 doctests), clippy, and fmt all pass.